### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -1,11 +1,30 @@
 .calendar {
   position: relative;
-  height: 640px; /* 16 h × 40 px */
+  height: 640px; /* 16 h × 40 px */
   border: 1px solid #e5e7eb;
   overflow: auto;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
 }
 
-.calendar-grid {
+.calendar-day {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
+}
+
+.calendar-day:last-child {
+  border-right: none;
+}
+
+.day-header {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2px 0;
+}
+
+.day-grid {
   position: relative;
   display: grid;
   width: 100%;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,11 @@
-import { parse, differenceInMinutes, isSameWeek, startOfWeek } from "date-fns";
+import {
+  parse,
+  differenceInMinutes,
+  differenceInCalendarDays,
+  isSameWeek,
+  startOfWeek,
+  startOfDay,
+} from "date-fns";
 
 const FORMAT = "MM/dd/yyyy h:mma";
 
@@ -6,6 +13,12 @@ export const toDate = (s: string): Date => parse(s, FORMAT, new Date());
 
 export const minutesFromWeekStart = (d: Date, weekStart: Date): number =>
   differenceInMinutes(d, weekStart);
+
+export const minutesFromDayStart = (d: Date): number =>
+  differenceInMinutes(d, startOfDay(d));
+
+export const dayIndexFromWeekStart = (d: Date, weekStart: Date): number =>
+  differenceInCalendarDays(d, weekStart);
 
 export const normalizeWeekStart = (d: Date): Date =>
   startOfWeek(d, { weekStartsOn: 0 });


### PR DESCRIPTION
## Summary
- rework WeeklyCalendar to display each day as a column with employee subcolumns
- add helper utils for day offsets and minutes from day start
- update PatientCheckinBox text
- adjust styles for new calendar layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c