### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -11,13 +11,15 @@
   width: 100%;
 }
 
+.day-labels,
 .employee-labels {
-  display: flex;
+  display: grid;
   margin-top: 6px;
+  width: 100%;
 }
 
+.day-labels .label,
 .employee-labels .label {
-  flex: 1;
   text-align: center;
   font-size: 12px;
   font-weight: 600;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,9 @@
-import { parse, differenceInMinutes, isSameWeek, startOfWeek } from "date-fns";
+import {
+  parse,
+  differenceInMinutes,
+  isSameWeek,
+  startOfWeek,
+} from "date-fns";
 
 const FORMAT = "MM/dd/yyyy h:mma";
 
@@ -12,3 +17,11 @@ export const normalizeWeekStart = (d: Date): Date =>
 
 export const inSameWeek = (ds: string, weekStart: Date): boolean =>
   isSameWeek(toDate(ds), weekStart, { weekStartsOn: 0 });
+
+/** Index of the day within the week starting at `weekStart` (0-6). */
+export const dayIndexFromWeekStart = (d: Date, weekStart: Date): number =>
+  Math.floor(minutesFromWeekStart(d, weekStart) / (60 * 24));
+
+/** Minutes from the start of the day for the given date. */
+export const minutesFromDayStart = (d: Date): number =>
+  d.getHours() * 60 + d.getMinutes();


### PR DESCRIPTION
## Summary
- add helpers for day index and day minutes
- lay out the calendar with day columns repeated for each employee
- display day and employee labels
- normalize whitespace in patient check-in box

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c