### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -11,13 +11,23 @@
   width: 100%;
 }
 
+.day-labels {
+  display: grid;
+  margin-bottom: 4px;
+}
+
+.day-label {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+}
+
 .employee-labels {
-  display: flex;
+  display: grid;
   margin-top: 6px;
 }
 
 .employee-labels .label {
-  flex: 1;
   text-align: center;
   font-size: 12px;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- show Patient Check-in label using normal spaces
- restructure calendar to group columns by day and employee
- add day and employee labels
- update styles for new layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c