### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -1,26 +1,63 @@
 .calendar {
   position: relative;
-  height: 640px; /* 16 h × 40 px */
+  height: 960px; /* 24 h × 40 px */
   border: 1px solid #e5e7eb;
   overflow: auto;
+  display: grid;
+  grid-template-columns: 50px repeat(7, 1fr);
 }
 
-.calendar-grid {
+.time-col {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
+}
+
+.time-label {
+  position: absolute;
+  width: 100%;
+  font-size: 10px;
+  text-align: right;
+  padding-right: 4px;
+  transform: translateY(-6px);
+}
+
+.calendar-day {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-day:last-child {
+  border-right: none;
+}
+
+.day-header {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2px 0;
+}
+
+.day-grid {
   position: relative;
   display: grid;
   width: 100%;
+  flex-grow: 1;
 }
 
 .employee-labels {
   display: flex;
-  margin-top: 6px;
+  border-bottom: 1px solid #e5e7eb;
 }
 
 .employee-labels .label {
   flex: 1;
   text-align: center;
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 600;
+  padding: 2px 0;
 }
 
 .item {
@@ -33,6 +70,15 @@
 
 .item.circle { border-radius: 50%; }
 .item.pill   { border-radius: 6px; }
+
+.item-label {
+  display: block;
+  font-size: 10px;
+  color: #ffffff;
+  text-align: center;
+  line-height: 1.2;
+  padding: 2px 2px;
+}
 
 .item:hover { transform: scale(1.15); }
 

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -1,16 +1,20 @@
 import React, { useMemo } from "react";
-import  type {
+import type {
   EmployeeData,
   EventRecord,
   RecordKind,
   AnyRecord,
+  LeadRecord,
+  PatientCheckinRecord,
 } from "../types.ts";
 import {
   toDate,
-  minutesFromWeekStart,
   inSameWeek,
   normalizeWeekStart,
+  minutesFromDayStart,
+  dayIndexFromWeekStart,
 } from "../utils/date";
+import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
 import EventBox from "./EventBox";
 import PatientCheckinBox from "./PatientCheckinBox";
@@ -25,6 +29,7 @@ const palette: Record<RecordKind, string> = {
 };
 
 type Positioned = {
+  day: number;
   col: number;
   top: number;
   height: number;
@@ -32,6 +37,7 @@ type Positioned = {
   color: string;
   rec: AnyRecord;
   type: RecordKind;
+  label?: string;
 };
 
 interface Props {
@@ -57,10 +63,12 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
 
             const st = toDate(ev.start);
             const en = toDate(ev.end);
+            const day = dayIndexFromWeekStart(st, base);
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(st, base) * (HOUR_HEIGHT / 60),
+              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
               height: Math.max(
                 (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
                 HOUR_HEIGHT / 2
@@ -69,20 +77,23 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
               color: palette.Event,
               rec: r,
               type: "Event",
+              label: `${format(st, "h:mma")}\u2013${format(en, "h:mma")}`,
             });
           } else {
             const ts =
               grp.type === "Patient Checkin"
-                ? (r as any).checkin
-                : (r as any).create;
+                ? (r as PatientCheckinRecord).checkin
+                : (r as LeadRecord).create;
 
             if (!inSameWeek(ts, base)) return;
 
             const d = toDate(ts);
+            const day = dayIndexFromWeekStart(d, base);
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(d, base) * (HOUR_HEIGHT / 60) - 6,
+              top: minutesFromDayStart(d) * (HOUR_HEIGHT / 60) - 6,
               height: 12,
               kind: "circle",
               color: palette[grp.type],
@@ -97,54 +108,84 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     return out;
   }, [data, base]);
 
-  const weekHeight = 7 * 24 * HOUR_HEIGHT;
+  const dayHeight = 24 * HOUR_HEIGHT;
+  const hours = useMemo(
+    () =>
+      Array.from({ length: 24 }, (_, i) => {
+        const d = new Date(base);
+        d.setHours(i, 0, 0, 0);
+        return format(d, "h a");
+      }),
+    [base]
+  );
+  const days = useMemo(() =>
+    Array.from({ length: 7 }, (_, i) => addDays(base, i)), [base]);
 
-  const renderBox = (it: Positioned) => {
-    switch (it.type) {
+  const renderBox = (rec: AnyRecord, type: RecordKind) => {
+    switch (type) {
       case "Lead":
-        return <LeadBox data={it.rec as any} />;
+        return <LeadBox data={rec as LeadRecord} />;
       case "Event":
-        return <EventBox data={it.rec as any} />;
+        return <EventBox data={rec as EventRecord} />;
       default:
-        return <PatientCheckinBox data={it.rec as any} />;
+        return <PatientCheckinBox data={rec as PatientCheckinRecord} />;
     }
   };
 
   return (
-    <>
-      <div className="calendar">
-        <div
-          className="calendar-grid"
-          style={{
-            gridTemplateColumns: `repeat(${data.length}, 1fr)`,
-            height: weekHeight,
-          }}
-        >
-          {items.map((it, i) => (
-            <div
-              key={i}
-              className={`item ${it.kind}`}
-              style={{
-                gridColumnStart: it.col,
-                top: `${it.top}px`,
-                height: it.kind === "circle" ? 12 : it.height,
-                background: it.color,
-              }}
-            >
-              <div className="hover">{renderBox(it)}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="employee-labels">
-        {data.map((emp) => (
-          <div key={emp.employee} className="label">
-            {emp.employee}
+    <div className="calendar">
+      <div className="time-col" style={{ height: dayHeight }}>
+        {hours.map((h, idx) => (
+          <div
+            key={idx}
+            className="time-label"
+            style={{ top: idx * HOUR_HEIGHT }}
+          >
+            {h}
           </div>
         ))}
       </div>
-    </>
+      {days.map((day, di) => (
+        <div key={di} className="calendar-day">
+          <div className="day-header">{format(day, "EEE MM/dd")}</div>
+          <div className="employee-labels">
+            {data.map((emp) => (
+              <div key={emp.employee} className="label">
+                {emp.employee
+                  .split(/\s+/)
+                  .map((p) => p[0])
+                  .join("")}
+              </div>
+            ))}
+          </div>
+          <div
+            className="day-grid"
+            style={{
+              gridTemplateColumns: `repeat(${data.length}, 1fr)`,
+              height: dayHeight,
+            }}
+          >
+            {items.filter((it) => it.day === di).map((it, i) => (
+              <div
+                key={i}
+                className={`item ${it.kind}`}
+                style={{
+                  gridColumnStart: it.col,
+                  top: `${it.top}px`,
+                  height: it.kind === "circle" ? 12 : it.height,
+                  background: it.color,
+                }}
+              >
+                {it.kind === "pill" && (
+                  <span className="item-label">{it.label}</span>
+                )}
+                <div className="hover">{renderBox(it.rec, it.type)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,11 @@
-import { parse, differenceInMinutes, isSameWeek, startOfWeek } from "date-fns";
+import {
+  parse,
+  differenceInMinutes,
+  differenceInCalendarDays,
+  isSameWeek,
+  startOfWeek,
+  startOfDay,
+} from "date-fns";
 
 const FORMAT = "MM/dd/yyyy h:mma";
 
@@ -6,6 +13,12 @@ export const toDate = (s: string): Date => parse(s, FORMAT, new Date());
 
 export const minutesFromWeekStart = (d: Date, weekStart: Date): number =>
   differenceInMinutes(d, weekStart);
+
+export const minutesFromDayStart = (d: Date): number =>
+  differenceInMinutes(d, startOfDay(d));
+
+export const dayIndexFromWeekStart = (d: Date, weekStart: Date): number =>
+  differenceInCalendarDays(d, weekStart);
 
 export const normalizeWeekStart = (d: Date): Date =>
   startOfWeek(d, { weekStartsOn: 0 });


### PR DESCRIPTION
## Summary
- rework WeeklyCalendar with time column and per-day employee columns
- show hour labels and event time ranges
- adjust calendar CSS for new layout and longer schedule

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c