### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -1,11 +1,44 @@
 .calendar {
   position: relative;
-  height: 640px; /* 16 h × 40 px */
+  height: 960px; /* 24 h × 40 px */
   border: 1px solid #e5e7eb;
   overflow: auto;
+  display: grid;
+  grid-template-columns: 56px repeat(7, 1fr);
 }
 
-.calendar-grid {
+.time-col {
+  border-right: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.time-label {
+  height: 40px;
+  padding-right: 4px;
+  text-align: right;
+  font-size: 10px;
+  line-height: 40px;
+  border-bottom: 1px dashed #e5e7eb;
+}
+
+.calendar-day {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
+}
+
+.calendar-day:last-child {
+  border-right: none;
+}
+
+.day-header {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2px 0;
+}
+
+.day-grid {
   position: relative;
   display: grid;
   width: 100%;
@@ -13,7 +46,7 @@
 
 .employee-labels {
   display: flex;
-  margin-top: 6px;
+  margin-bottom: 6px;
 }
 
 .employee-labels .label {
@@ -32,7 +65,19 @@
 }
 
 .item.circle { border-radius: 50%; }
-.item.pill   { border-radius: 6px; }
+.item.pill {
+  border-radius: 6px;
+  color: #fff;
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 2px;
+}
+
+.item-label {
+  pointer-events: none;
+}
 
 .item:hover { transform: scale(1.15); }
 

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -1,16 +1,20 @@
 import React, { useMemo } from "react";
-import  type {
+import type {
   EmployeeData,
   EventRecord,
   RecordKind,
   AnyRecord,
+  LeadRecord,
+  PatientCheckinRecord,
 } from "../types.ts";
 import {
   toDate,
-  minutesFromWeekStart,
   inSameWeek,
   normalizeWeekStart,
+  minutesFromDayStart,
+  dayIndexFromWeekStart,
 } from "../utils/date";
+import { format, addDays, addHours, startOfDay } from "date-fns";
 import LeadBox from "./LeadBox";
 import EventBox from "./EventBox";
 import PatientCheckinBox from "./PatientCheckinBox";
@@ -25,6 +29,7 @@ const palette: Record<RecordKind, string> = {
 };
 
 type Positioned = {
+  day: number;
   col: number;
   top: number;
   height: number;
@@ -32,6 +37,7 @@ type Positioned = {
   color: string;
   rec: AnyRecord;
   type: RecordKind;
+  label?: string;
 };
 
 interface Props {
@@ -57,10 +63,13 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
 
             const st = toDate(ev.start);
             const en = toDate(ev.end);
+            const day = dayIndexFromWeekStart(st, base);
+            const label = `${format(st, "h:mma")} - ${format(en, "h:mma")}`;
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(st, base) * (HOUR_HEIGHT / 60),
+              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
               height: Math.max(
                 (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
                 HOUR_HEIGHT / 2
@@ -69,20 +78,23 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
               color: palette.Event,
               rec: r,
               type: "Event",
+              label,
             });
           } else {
             const ts =
               grp.type === "Patient Checkin"
-                ? (r as any).checkin
-                : (r as any).create;
+                ? (r as PatientCheckinRecord).checkin
+                : (r as LeadRecord).create;
 
             if (!inSameWeek(ts, base)) return;
 
             const d = toDate(ts);
+            const day = dayIndexFromWeekStart(d, base);
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(d, base) * (HOUR_HEIGHT / 60) - 6,
+              top: minutesFromDayStart(d) * (HOUR_HEIGHT / 60) - 6,
               height: 12,
               kind: "circle",
               color: palette[grp.type],
@@ -97,54 +109,85 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     return out;
   }, [data, base]);
 
-  const weekHeight = 7 * 24 * HOUR_HEIGHT;
+  const dayHeight = 24 * HOUR_HEIGHT;
+  const days = useMemo(() =>
+    Array.from({ length: 7 }, (_, i) => addDays(base, i)), [base]);
+  const times = useMemo(
+    () =>
+      Array.from({ length: 25 }, (_, i) =>
+        format(addHours(startOfDay(base), i), "h a")
+      ),
+    [base]
+  );
 
-  const renderBox = (it: Positioned) => {
-    switch (it.type) {
+  const renderBox = (rec: AnyRecord, type: RecordKind) => {
+    switch (type) {
       case "Lead":
-        return <LeadBox data={it.rec as any} />;
+        return <LeadBox data={rec as LeadRecord} />;
       case "Event":
-        return <EventBox data={it.rec as any} />;
+        return <EventBox data={rec as EventRecord} />;
       default:
-        return <PatientCheckinBox data={it.rec as any} />;
+        return <PatientCheckinBox data={rec as PatientCheckinRecord} />;
     }
   };
 
-  return (
-    <>
-      <div className="calendar">
-        <div
-          className="calendar-grid"
-          style={{
-            gridTemplateColumns: `repeat(${data.length}, 1fr)`,
-            height: weekHeight,
-          }}
-        >
-          {items.map((it, i) => (
-            <div
-              key={i}
-              className={`item ${it.kind}`}
-              style={{
-                gridColumnStart: it.col,
-                top: `${it.top}px`,
-                height: it.kind === "circle" ? 12 : it.height,
-                background: it.color,
-              }}
-            >
-              <div className="hover">{renderBox(it)}</div>
-            </div>
-          ))}
-        </div>
-      </div>
+  const abbr = (name: string) =>
+    name
+      .split(/\s+/)
+      .map((n) => n[0])
+      .join("");
 
-      <div className="employee-labels">
-        {data.map((emp) => (
-          <div key={emp.employee} className="label">
-            {emp.employee}
+  return (
+    <div className="calendar">
+      <div className="time-col">
+        {times.map((t, i) => (
+          <div
+            key={i}
+            className="time-label"
+            style={{ height: HOUR_HEIGHT }}
+          >
+            {t}
           </div>
         ))}
       </div>
-    </>
+      {days.map((day, di) => (
+        <div key={di} className="calendar-day">
+          <div className="day-header">{format(day, "EEE MM/dd")}</div>
+          <div className="employee-labels">
+            {data.map((emp) => (
+              <div key={emp.employee} className="label">
+                {abbr(emp.employee)}
+              </div>
+            ))}
+          </div>
+          <div
+            className="day-grid"
+            style={{
+              gridTemplateColumns: `repeat(${data.length}, 1fr)`,
+              height: dayHeight,
+            }}
+          >
+            {items.filter((it) => it.day === di).map((it, i) => (
+              <div
+                key={i}
+                className={`item ${it.kind}`}
+                style={{
+                  gridColumnStart: it.col,
+                  top: `${it.top}px`,
+                  height: it.kind === "circle" ? 12 : it.height,
+                  background: it.color,
+                }}
+              >
+                {it.kind === "pill" && (
+                  <div className="item-label">{it.label}</div>
+                )}
+                <div className="hover">{renderBox(it.rec, it.type)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,11 @@
-import { parse, differenceInMinutes, isSameWeek, startOfWeek } from "date-fns";
+import {
+  parse,
+  differenceInMinutes,
+  differenceInCalendarDays,
+  isSameWeek,
+  startOfWeek,
+  startOfDay,
+} from "date-fns";
 
 const FORMAT = "MM/dd/yyyy h:mma";
 
@@ -6,6 +13,12 @@ export const toDate = (s: string): Date => parse(s, FORMAT, new Date());
 
 export const minutesFromWeekStart = (d: Date, weekStart: Date): number =>
   differenceInMinutes(d, weekStart);
+
+export const minutesFromDayStart = (d: Date): number =>
+  differenceInMinutes(d, startOfDay(d));
+
+export const dayIndexFromWeekStart = (d: Date, weekStart: Date): number =>
+  differenceInCalendarDays(d, weekStart);
 
 export const normalizeWeekStart = (d: Date): Date =>
   startOfWeek(d, { weekStartsOn: 0 });


### PR DESCRIPTION
## Summary
- rework day layout with employee headers and time column
- add time range labels to event pills
- tweak styles for new grid structure

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c