### PR TITLE
Fix weekly calendar layout

### DIFF
--- a/src/components/PatientCheckinBox.tsx
+++ b/src/components/PatientCheckinBox.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const PatientCheckinBox: React.FC<Props> = ({ data }) => (
   <div className="record-box pcheck">
-    <strong>Patient Check‑in</strong>
+    <strong>Patient Check-in</strong>
     <div>{data.patient}</div>
     <div className="meta">{data.notes}</div>
     <div className="meta">{data.checkin}</div>

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -1,26 +1,58 @@
 .calendar {
   position: relative;
-  height: 640px; /* 16 h × 40 px */
+  height: 960px; /* 24 h × 40 px */
   border: 1px solid #e5e7eb;
   overflow: auto;
-}
-
-.calendar-grid {
-  position: relative;
   display: grid;
-  width: 100%;
+  grid-template-columns: 50px repeat(7, 1fr);
 }
 
-.employee-labels {
-  display: flex;
-  margin-top: 6px;
+.time-col {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
 }
 
-.employee-labels .label {
-  flex: 1;
+.time-label {
+  height: 40px;
+  font-size: 10px;
+  line-height: 40px;
+  text-align: right;
+  padding-right: 4px;
+  box-sizing: border-box;
+}
+
+.calendar-day {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
+}
+
+.calendar-day:last-child {
+  border-right: none;
+}
+
+.day-header {
   text-align: center;
   font-size: 12px;
   font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2px 0;
+}
+
+.employee-labels {
+  display: grid;
+  grid-auto-flow: column;
+}
+
+.employee-labels .label {
+  text-align: center;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.day-grid {
+  position: relative;
+  display: grid;
+  width: 100%;
 }
 
 .item {
@@ -32,7 +64,15 @@
 }
 
 .item.circle { border-radius: 50%; }
-.item.pill   { border-radius: 6px; }
+.item.pill {
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-size: 10px;
+  padding: 0 2px;
+}
 
 .item:hover { transform: scale(1.15); }
 

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -1,16 +1,21 @@
 import React, { useMemo } from "react";
-import  type {
+import type {
   EmployeeData,
   EventRecord,
   RecordKind,
   AnyRecord,
+  LeadRecord,
+  PatientCheckinRecord,
 } from "../types.ts";
 import {
   toDate,
-  minutesFromWeekStart,
   inSameWeek,
   normalizeWeekStart,
+  minutesFromDayStart,
+  dayIndexFromWeekStart,
+  formatRange,
 } from "../utils/date";
+import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
 import EventBox from "./EventBox";
 import PatientCheckinBox from "./PatientCheckinBox";
@@ -25,6 +30,7 @@ const palette: Record<RecordKind, string> = {
 };
 
 type Positioned = {
+  day: number;
   col: number;
   top: number;
   height: number;
@@ -57,10 +63,12 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
 
             const st = toDate(ev.start);
             const en = toDate(ev.end);
+            const day = dayIndexFromWeekStart(st, base);
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(st, base) * (HOUR_HEIGHT / 60),
+              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
               height: Math.max(
                 (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
                 HOUR_HEIGHT / 2
@@ -73,16 +81,18 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
           } else {
             const ts =
               grp.type === "Patient Checkin"
-                ? (r as any).checkin
-                : (r as any).create;
+                ? (r as PatientCheckinRecord).checkin
+                : (r as LeadRecord).create;
 
             if (!inSameWeek(ts, base)) return;
 
             const d = toDate(ts);
+            const day = dayIndexFromWeekStart(d, base);
 
             out.push({
+              day,
               col: colIdx + 1,
-              top: minutesFromWeekStart(d, base) * (HOUR_HEIGHT / 60) - 6,
+              top: minutesFromDayStart(d) * (HOUR_HEIGHT / 60) - 6,
               height: 12,
               kind: "circle",
               color: palette[grp.type],
@@ -97,54 +107,82 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     return out;
   }, [data, base]);
 
-  const weekHeight = 7 * 24 * HOUR_HEIGHT;
+  const dayHeight = 24 * HOUR_HEIGHT;
+  const days = useMemo(() =>
+    Array.from({ length: 7 }, (_, i) => addDays(base, i)), [base]);
+  const hours = useMemo(
+    () =>
+      Array.from({ length: 25 }, (_, i) =>
+        format(new Date(2020, 0, 1, i), "haaa"),
+      ),
+    [],
+  );
 
-  const renderBox = (it: Positioned) => {
-    switch (it.type) {
+  const abbr = (name: string): string =>
+    name
+      .split(/\s+/)
+      .map((p) => p[0])
+      .join("")
+      .toUpperCase();
+
+  const renderBox = (rec: AnyRecord, type: RecordKind) => {
+    switch (type) {
       case "Lead":
-        return <LeadBox data={it.rec as any} />;
+        return <LeadBox data={rec as LeadRecord} />;
       case "Event":
-        return <EventBox data={it.rec as any} />;
+        return <EventBox data={rec as EventRecord} />;
       default:
-        return <PatientCheckinBox data={it.rec as any} />;
+        return <PatientCheckinBox data={rec as PatientCheckinRecord} />;
     }
   };
 
   return (
-    <>
-      <div className="calendar">
-        <div
-          className="calendar-grid"
-          style={{
-            gridTemplateColumns: `repeat(${data.length}, 1fr)`,
-            height: weekHeight,
-          }}
-        >
-          {items.map((it, i) => (
-            <div
-              key={i}
-              className={`item ${it.kind}`}
-              style={{
-                gridColumnStart: it.col,
-                top: `${it.top}px`,
-                height: it.kind === "circle" ? 12 : it.height,
-                background: it.color,
-              }}
-            >
-              <div className="hover">{renderBox(it)}</div>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div className="employee-labels">
-        {data.map((emp) => (
-          <div key={emp.employee} className="label">
-            {emp.employee}
+    <div className="calendar">
+      <div className="time-col">
+        {hours.map((h, i) => (
+          <div key={i} className="time-label">
+            {h}
           </div>
         ))}
       </div>
-    </>
+      {days.map((day, di) => (
+        <div key={di} className="calendar-day">
+          <div className="day-header">{format(day, "EEE MM/dd")}</div>
+          <div className="employee-labels" style={{ gridTemplateColumns: `repeat(${data.length}, 1fr)` }}>
+            {data.map((emp) => (
+              <div key={emp.employee} className="label">
+                {abbr(emp.employee)}
+              </div>
+            ))}
+          </div>
+          <div
+            className="day-grid"
+            style={{
+              gridTemplateColumns: `repeat(${data.length}, 1fr)`,
+              height: dayHeight,
+            }}
+          >
+            {items.filter((it) => it.day === di).map((it, i) => (
+              <div
+                key={i}
+                className={`item ${it.kind}`}
+                style={{
+                  gridColumnStart: it.col,
+                  top: `${it.top}px`,
+                  height: it.kind === "circle" ? 12 : it.height,
+                  background: it.color,
+                }}
+              >
+                {it.kind === "pill" && (
+                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
+                )}
+                <div className="hover">{renderBox(it.rec, it.type)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,12 @@
-import { parse, differenceInMinutes, isSameWeek, startOfWeek } from "date-fns";
+import {
+  parse,
+  differenceInMinutes,
+  differenceInCalendarDays,
+  isSameWeek,
+  startOfWeek,
+  startOfDay,
+  format,
+} from "date-fns";
 
 const FORMAT = "MM/dd/yyyy h:mma";
 
@@ -7,8 +15,20 @@ export const toDate = (s: string): Date => parse(s, FORMAT, new Date());
 export const minutesFromWeekStart = (d: Date, weekStart: Date): number =>
   differenceInMinutes(d, weekStart);
 
+export const minutesFromDayStart = (d: Date): number =>
+  differenceInMinutes(d, startOfDay(d));
+
+export const dayIndexFromWeekStart = (d: Date, weekStart: Date): number =>
+  differenceInCalendarDays(d, weekStart);
+
 export const normalizeWeekStart = (d: Date): Date =>
   startOfWeek(d, { weekStartsOn: 0 });
 
 export const inSameWeek = (ds: string, weekStart: Date): boolean =>
   isSameWeek(toDate(ds), weekStart, { weekStartsOn: 0 });
+
+export const formatTime = (s: string): string =>
+  format(toDate(s), "h:mma").toLowerCase();
+
+export const formatRange = (s: string, e: string): string =>
+  `${formatTime(s)}-${formatTime(e)}`;


### PR DESCRIPTION
## Summary
- update calendar layout to include hourly column and employee subcolumns
- show abbreviated employee names and display event time range
- add helpers for formatting time ranges

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889333f16d88320a6c4206b9527ff6c