### PR TITLE
Fix weekly calendar layout and item styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,8 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 2rem;
+  box-sizing: border-box;
   text-align: center;
 }
 

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -55,15 +56,24 @@
   width: 100%;
 }
 
+.emp-col {
+  position: relative;
+}
+
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
+  left: 0;
+  width: 100%;
   cursor: pointer;
   transition: transform .18s ease;
 }
 
-.item.circle { border-radius: 50%; }
+.item.circle {
+  width: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 50%;
+}
 .item.pill {
   border-radius: 6px;
   display: flex;

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -162,21 +162,31 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
               height: dayHeight,
             }}
           >
-            {items.filter((it) => it.day === di).map((it, i) => (
-              <div
-                key={i}
-                className={`item ${it.kind}`}
-                style={{
-                  gridColumnStart: it.col,
-                  top: `${it.top}px`,
-                  height: it.kind === "circle" ? 12 : it.height,
-                  background: it.color,
-                }}
-              >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
-                )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
+            {data.map((emp, ei) => (
+              <div key={emp.employee} className="emp-col">
+                {items
+                  .filter((it) => it.day === di && it.col === ei + 1)
+                  .map((it, i) => (
+                    <div
+                      key={i}
+                      className={`item ${it.kind}`}
+                      style={{
+                        top: `${it.top}px`,
+                        height: it.kind === "circle" ? 12 : it.height,
+                        background: it.color,
+                      }}
+                    >
+                      {it.kind === "pill" && (
+                        <span>
+                          {formatRange(
+                            (it.rec as EventRecord).start,
+                            (it.rec as EventRecord).end,
+                          )}
+                        </span>
+                      )}
+                      <div className="hover">{renderBox(it.rec, it.type)}</div>
+                    </div>
+                  ))}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- make the app container full width
- allow calendar to fill the screen width
- render calendar items inside employee columns
- adjust styles so circles are centered and pills fill the column

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac