### PR TITLE
Improve weekly calendar layout

### DIFF
--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100vw;
 }
 
 .time-col {
@@ -57,15 +58,19 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
   transition: transform .18s ease;
 }
 
-.item.circle { border-radius: 50%; }
+.item.circle {
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
 .item.pill {
   border-radius: 6px;
+  left: 10%;
+  width: 80%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,6 +80,7 @@
 }
 
 .item:hover { transform: scale(1.15); }
+.item.circle:hover { transform: translateX(-50%) scale(1.15); }
 
 .item .hover {
   display: none;

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -65,18 +65,22 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
             const en = toDate(ev.end);
             const day = dayIndexFromWeekStart(st, base);
 
-            out.push({
-              day,
-              col: colIdx + 1,
-              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
-              height: Math.max(
-                (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
-                HOUR_HEIGHT / 2
-              ),
-              kind: "pill",
-              color: palette.Event,
-              rec: r,
-              type: "Event",
+            ev.employees.forEach((ename) => {
+              const idx = data.findIndex((e) => e.employee === ename);
+              if (idx === -1) return;
+              out.push({
+                day,
+                col: idx + 1,
+                top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
+                height: Math.max(
+                  (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
+                  HOUR_HEIGHT / 2
+                ),
+                kind: "pill",
+                color: palette.Event,
+                rec: r,
+                type: "Event",
+              });
             });
           } else {
             const ts =
@@ -171,6 +175,8 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
                   top: `${it.top}px`,
                   height: it.kind === "circle" ? 12 : it.height,
                   background: it.color,
+                  width: it.kind === "circle" ? 12 : "80%",
+                  left: it.kind === "circle" ? "50%" : "10%",
                 }}
               >
                 {it.kind === "pill" && (


### PR DESCRIPTION
## Summary
- assign events to employee columns using the event's employee list
- make calendar fill the viewport width
- ensure circles and event pills have correct shapes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac