### PR TITLE
Fix calendar layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: 2rem;
   text-align: center;
 }

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -57,13 +58,16 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
   transition: transform .18s ease;
+  width: 100%;
+  left: 0;
 }
 
-.item.circle { border-radius: 50%; }
+.item.circle {
+  border-radius: 50%;
+  width: 12px;
+}
 .item.pill {
   border-radius: 6px;
   display: flex;

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -60,6 +60,7 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
           if (grp.type === "Event") {
             const ev = r as EventRecord;
             if (!inSameWeek(ev.start, base)) return;
+            if (!ev.employees.includes(emp.employee)) return;
 
             const st = toDate(ev.start);
             const en = toDate(ev.end);
@@ -136,6 +137,8 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     }
   };
 
+  const colWidth = 100 / data.length;
+
   return (
     <div className="calendar">
       <div className="time-col">
@@ -167,10 +170,16 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
                 key={i}
                 className={`item ${it.kind}`}
                 style={{
-                  gridColumnStart: it.col,
                   top: `${it.top}px`,
                   height: it.kind === "circle" ? 12 : it.height,
                   background: it.color,
+                  left:
+                    it.kind === "circle"
+                      ? `calc(${(it.col - 1) * colWidth}% + ${(colWidth / 2).toFixed(
+                          2,
+                        )}% - 6px)`
+                      : `${(it.col - 1) * colWidth}%`,
+                  width: it.kind === "circle" ? "12px" : `${colWidth}%`,
                 }}
               >
                 {it.kind === "pill" && (


### PR DESCRIPTION
## Summary
- make calendar width follow screen size
- ensure events are placed within their employee column
- tweak circle & pill appearance

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac