### PR TITLE
Improve weekly calendar layout

### DIFF
--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100vw;
 }
 
 .time-col {
@@ -57,32 +58,46 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
+  overflow: hidden;
+  transition: width .2s ease, height .2s ease, transform .18s ease;
+  z-index: 1;
 }
 
-.item.circle { border-radius: 50%; }
+.item.circle {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
 .item.pill {
   border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  left: 10%;
+  width: 80%;
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
-
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+.item:hover {
+  width: 180px;
+  height: auto;
+  background: none !important;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item.circle:hover {
+  transform: translateX(-50%);
+  border-radius: 4px;
+}
+
+.item.pill:hover {
+  border-radius: 4px;
+}
+.item .content {
+  display: none;
+}
+.item:hover .content {
+  display: block;
+}

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -13,7 +13,6 @@ import {
   normalizeWeekStart,
   minutesFromDayStart,
   dayIndexFromWeekStart,
-  formatRange,
 } from "../utils/date";
 import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
@@ -65,18 +64,22 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
             const en = toDate(ev.end);
             const day = dayIndexFromWeekStart(st, base);
 
-            out.push({
-              day,
-              col: colIdx + 1,
-              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
-              height: Math.max(
-                (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
-                HOUR_HEIGHT / 2
-              ),
-              kind: "pill",
-              color: palette.Event,
-              rec: r,
-              type: "Event",
+            ev.employees.forEach((ename) => {
+              const idx = data.findIndex((e) => e.employee === ename);
+              if (idx === -1) return;
+              out.push({
+                day,
+                col: idx + 1,
+                top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
+                height: Math.max(
+                  (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
+                  HOUR_HEIGHT / 2
+                ),
+                kind: "pill",
+                color: palette.Event,
+                rec: r,
+                type: "Event",
+              });
             });
           } else {
             const ts =
@@ -173,10 +176,7 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
                   background: it.color,
                 }}
               >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
-                )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
+                <div className="content">{renderBox(it.rec, it.type)}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- assign events to employee columns using the event's employee list
- make calendar fill the viewport width
- ensure circles and event pills have correct shapes
- transform circles and pills into record boxes on hover
- remove time text from pills

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac