### PR TITLE
Improve weekly calendar layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,7 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100vw;
+  margin: 0;
+  padding: 0;
 }
 
 .logo {

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100vw;
 }
 
 .time-col {
@@ -57,32 +58,40 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
+  overflow: hidden;
+  transition: width .18s ease, height .18s ease, border-radius .18s ease,
+    transform .18s ease;
 }
 
-.item.circle { border-radius: 50%; }
+.item.circle {
+  border-radius: 50%;
+  transform: translateX(-50%);
+}
+
 .item.pill {
   border-radius: 6px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #ffffff;
-  font-size: 10px;
-  padding: 0 2px;
+  left: 10%;
+  width: 80%;
 }
-
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
-  display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+.item:hover {
+  width: 180px !important;
+  background: none;
+  left: 0 !important;
+  transform: none;
+  border-radius: 4px;
   z-index: 20;
+  overflow: visible;
+  height: auto !important;
 }
 
-.item:hover .hover { display: block; }
+.item.circle:hover {
+  transform: none;
+}
+.item .details {
+  display: none;
+}
+
+.item:hover .details {
+  display: block;
+}

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -13,7 +13,6 @@ import {
   normalizeWeekStart,
   minutesFromDayStart,
   dayIndexFromWeekStart,
-  formatRange,
 } from "../utils/date";
 import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
@@ -65,18 +64,22 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
             const en = toDate(ev.end);
             const day = dayIndexFromWeekStart(st, base);
 
-            out.push({
-              day,
-              col: colIdx + 1,
-              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
-              height: Math.max(
-                (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
-                HOUR_HEIGHT / 2
-              ),
-              kind: "pill",
-              color: palette.Event,
-              rec: r,
-              type: "Event",
+            ev.employees.forEach((ename) => {
+              const idx = data.findIndex((e) => e.employee === ename);
+              if (idx === -1) return;
+              out.push({
+                day,
+                col: idx + 1,
+                top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
+                height: Math.max(
+                  (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
+                  HOUR_HEIGHT / 2
+                ),
+                kind: "pill",
+                color: palette.Event,
+                rec: r,
+                type: "Event",
+              });
             });
           } else {
             const ts =
@@ -171,12 +174,11 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
                   top: `${it.top}px`,
                   height: it.kind === "circle" ? 12 : it.height,
                   background: it.color,
+                  width: it.kind === "circle" ? 12 : "80%",
+                  left: it.kind === "circle" ? "50%" : "10%",
                 }}
               >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
-                )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
+                <div className="details">{renderBox(it.rec, it.type)}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- remove width constraint from root container so calendar fills the viewport
- remove time text from event pills
- reveal record boxes by expanding the pill/circle on hover

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac