### PR TITLE
Improve calendar item placement and styling

### DIFF
--- a/src/components/RecordBox.css
+++ b/src/components/RecordBox.css
@@ -5,6 +5,7 @@
   padding: 8px;
   font-size: 12px;
   background: #ffffff;
+  color: #000000;
   border-radius: 4px;
   box-shadow: 0 0 2px rgba(0, 0, 0, .35);
   max-width: 180px;

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -57,32 +58,46 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
-}
-
-.item.circle { border-radius: 50%; }
-.item.pill {
-  border-radius: 6px;
+  transition: all .2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  background-color: var(--bg-color);
+  height: var(--item-height);
+}
+
+.item.circle {
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.item.pill {
+  border-radius: 999px;
+  left: 10%;
+  width: 80%;
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
 
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
+.item-content {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+}
+
+.item:hover {
+  background: transparent;
+  left: 0;
+  width: 180px;
+  height: auto;
+  border-radius: 4px;
+  transform: none;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item:hover .item-content {
+  display: block;
+}

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -13,7 +13,6 @@ import {
   normalizeWeekStart,
   minutesFromDayStart,
   dayIndexFromWeekStart,
-  formatRange,
 } from "../utils/date";
 import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
@@ -60,6 +59,7 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
           if (grp.type === "Event") {
             const ev = r as EventRecord;
             if (!inSameWeek(ev.start, base)) return;
+            if (!ev.employees.includes(emp.employee)) return;
 
             const st = toDate(ev.start);
             const en = toDate(ev.end);
@@ -169,14 +169,11 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
                 style={{
                   gridColumnStart: it.col,
                   top: `${it.top}px`,
-                  height: it.kind === "circle" ? 12 : it.height,
-                  background: it.color,
+                  "--item-height": it.kind === "circle" ? "12px" : `${it.height}px`,
+                  "--bg-color": it.color,
                 }}
               >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
-                )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
+                <div className="item-content">{renderBox(it.rec, it.type)}</div>
               </div>
             ))}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ a:hover {
   color: #535bf2;
 }
 
+html, body, #root {
+  width: 100%;
+}
+
 body {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- restrict event items to assigned employee columns
- fix pill styles and ensure background color shows
- use pill shapes with fully rounded ends
- ensure record box text is readable

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac