### PR TITLE
Add employee column component

### DIFF
--- a/src/components/EmployeeColumn.tsx
+++ b/src/components/EmployeeColumn.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import type { AnyRecord, RecordKind, EventRecord, LeadRecord, PatientCheckinRecord } from "../types";
+import LeadBox from "./LeadBox";
+import EventBox from "./EventBox";
+import PatientCheckinBox from "./PatientCheckinBox";
+import "./WeeklyCalendar.css";
+
+export interface ColumnItem {
+  top: number;
+  height: number;
+  kind: "circle" | "pill";
+  color: string;
+  rec: AnyRecord;
+  type: RecordKind;
+}
+
+interface Props {
+  label: string;
+  items: ColumnItem[];
+  dayHeight: number;
+}
+
+const renderBox = (rec: AnyRecord, type: RecordKind) => {
+  switch (type) {
+    case "Lead":
+      return <LeadBox data={rec as LeadRecord} />;
+    case "Event":
+      return <EventBox data={rec as EventRecord} />;
+    default:
+      return <PatientCheckinBox data={rec as PatientCheckinRecord} />;
+  }
+};
+
+const EmployeeColumn: React.FC<Props> = ({ label, items, dayHeight }) => (
+  <div className="employee-column">
+    <div className="emp-label">{label}</div>
+    <div className="emp-grid" style={{ height: dayHeight }}>
+      {items.map((it, i) => (
+        <div
+          key={i}
+          className={`item ${it.kind}`}
+          style={{
+            top: `${it.top}px`,
+            "--item-height": it.kind === "circle" ? "12px" : `${it.height}px`,
+            "--bg-color": it.color,
+          } as React.CSSProperties}
+        >
+          <div className="item-content">{renderBox(it.rec, it.type)}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default EmployeeColumn;

--- a/src/components/RecordBox.css
+++ b/src/components/RecordBox.css
@@ -5,6 +5,7 @@
   padding: 8px;
   font-size: 12px;
   background: #ffffff;
+  color: #000000;
   border-radius: 4px;
   box-shadow: 0 0 2px rgba(0, 0, 0, .35);
   max-width: 180px;

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100vw;
 }
 
 .time-col {
@@ -38,15 +39,28 @@
   padding: 2px 0;
 }
 
-.employee-labels {
-  display: grid;
-  grid-auto-flow: column;
+
+.employee-column {
+  position: relative;
+  border-right: 1px solid #e5e7eb;
 }
 
-.employee-labels .label {
+.employee-column:last-child {
+  border-right: none;
+}
+
+.emp-label {
   text-align: center;
   font-size: 12px;
   font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2px 0;
+}
+
+.emp-grid {
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .day-grid {
@@ -57,32 +71,46 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
-}
-
-.item.circle { border-radius: 50%; }
-.item.pill {
-  border-radius: 6px;
+  transition: all .2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--bg-color);
+  height: var(--item-height);
+}
+
+.item.circle {
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.item.pill {
+  border-radius: 999px;
+  left: 10%;
+  width: 80%;
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
 
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
+.item-content {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+}
+
+.item:hover {
+  background: transparent;
+  left: 0;
+  width: 180px;
+  height: auto;
+  border-radius: 4px;
+  transform: none;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item:hover .item-content {
+  display: block;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ a:hover {
   color: #535bf2;
 }
 
+html, body, #root {
+  width: 100%;
+}
+
 body {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- create `EmployeeColumn` for per-employee day slots
- shift weekly calendar to use new column component
- style new column and keep circular pills

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac