### PR TITLE
Improve week navigation and add record controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,101 @@
-import React from "react";
+import React, { useState } from "react";
 import WeeklyCalendar from "./components/WeeklyCalendar";
-import type { EmployeeData } from "./types";
+import CalendarControls from "./components/CalendarControls";
+import type {
+  EmployeeData,
+  LeadRecord,
+  EventRecord,
+  PatientCheckinRecord,
+} from "./types";
 import { normalizeWeekStart } from "./utils/date";
 import data from "./data/fake_data.json";
+import { format, addDays } from "date-fns";
 import "./components/WeeklyCalendar.css";
 import "./components/RecordBox.css";
 
-const employees = data as unknown as EmployeeData[];
+const initial = data as unknown as EmployeeData[];
 
-const App: React.FC = () => (
-  <WeeklyCalendar
-    data={employees}
-    weekStart={normalizeWeekStart(new Date())}
-  />
-);
+const App: React.FC = () => {
+  const [weekStart, setWeekStart] = useState(normalizeWeekStart(new Date()));
+  const [employees, setEmployees] = useState<EmployeeData[]>(initial);
+
+  const addRecord = (
+    empName: string,
+    type: "Lead" | "Event" | "Patient Checkin",
+    rec: LeadRecord | EventRecord | PatientCheckinRecord,
+  ) => {
+    setEmployees((prev) =>
+      prev.map((emp) => {
+        if (emp.employee !== empName) return emp;
+        const groups = [...emp.records];
+        const idx = groups.findIndex((g) => g.type === type);
+        if (idx >= 0) {
+          groups[idx] = {
+            ...groups[idx],
+            records: [...groups[idx].records, rec],
+          };
+        } else {
+          groups.push({ type, records: [rec] });
+        }
+        return { ...emp, records: groups };
+      }),
+    );
+  };
+
+  const addLead = () => {
+    const emp = employees[0];
+    const record: LeadRecord = {
+      firstname: "New",
+      lastname: "Lead",
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    };
+    addRecord(emp.employee, "Lead", record);
+  };
+
+  const addEvent = () => {
+    const emp = employees[0];
+    const st = addDays(weekStart, 1);
+    st.setHours(9, 0, 0, 0);
+    const en = addDays(weekStart, 1);
+    en.setHours(10, 0, 0, 0);
+    const record: EventRecord = {
+      title: "New Event",
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+      start: format(st, "MM/dd/yyyy h:mma"),
+      end: format(en, "MM/dd/yyyy h:mma"),
+      employees: [emp.employee],
+    };
+    addRecord(emp.employee, "Event", record);
+  };
+
+  const addCheckin = () => {
+    const emp = employees[0];
+    const d = addDays(weekStart, 1);
+    d.setHours(12, 0, 0, 0);
+    const record: PatientCheckinRecord = {
+      patient: "New Patient",
+      notes: "Walk-in",
+      checkin: format(d, "MM/dd/yyyy h:mma"),
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    };
+    addRecord(emp.employee, "Patient Checkin", record);
+  };
+
+  const nextWeek = () => setWeekStart((w) => addDays(w, 7));
+  const prevWeek = () => setWeekStart((w) => addDays(w, -7));
+
+  return (
+    <div>
+      <CalendarControls
+        onPrev={prevWeek}
+        onNext={nextWeek}
+        onAddLead={addLead}
+        onAddEvent={addEvent}
+        onAddCheckin={addCheckin}
+      />
+      <WeeklyCalendar data={employees} weekStart={weekStart} />
+    </div>
+  );
+};
 
 export default App;

--- a/src/components/CalendarControls.tsx
+++ b/src/components/CalendarControls.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  onPrev: () => void;
+  onNext: () => void;
+  onAddLead: () => void;
+  onAddEvent: () => void;
+  onAddCheckin: () => void;
+}
+
+const CalendarControls: React.FC<Props> = ({
+  onPrev,
+  onNext,
+  onAddLead,
+  onAddEvent,
+  onAddCheckin,
+}) => (
+  <div className="calendar-controls">
+    <button onClick={onPrev}>Prev Week</button>
+    <button onClick={onNext}>Next Week</button>
+    <button onClick={onAddLead}>Add Lead</button>
+    <button onClick={onAddEvent}>Add Event</button>
+    <button onClick={onAddCheckin}>Add Checkin</button>
+  </div>
+);
+
+export default CalendarControls;

--- a/src/components/EmployeeColumn.tsx
+++ b/src/components/EmployeeColumn.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { CalendarItem, RecordKind, AnyRecord } from "../types";
+
+interface Props {
+  label: string;
+  items: CalendarItem[];
+  dayHeight: number;
+  renderBox: (rec: AnyRecord, type: RecordKind) => React.ReactNode;
+}
+
+const EmployeeColumn: React.FC<Props> = ({ label, items, dayHeight, renderBox }) => (
+  <div className="employee-col" style={{ height: dayHeight }}>
+    <div className="employee-label">{label}</div>
+    {items.map((it, i) => (
+      <div
+        key={i}
+        className={`item ${it.kind}`}
+        style={{
+          top: `${it.top}px`,
+          "--item-height": it.kind === "circle" ? "12px" : `${it.height}px`,
+          "--bg-color": it.color,
+        } as React.CSSProperties}
+      >
+        <div className="item-content">{renderBox(it.rec, it.type)}</div>
+      </div>
+    ))}
+  </div>
+);
+
+export default EmployeeColumn;

--- a/src/components/RecordBox.css
+++ b/src/components/RecordBox.css
@@ -5,6 +5,7 @@
   padding: 8px;
   font-size: 12px;
   background: #ffffff;
+  color: #000000;
   border-radius: 4px;
   box-shadow: 0 0 2px rgba(0, 0, 0, .35);
   max-width: 180px;

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -23,7 +24,7 @@
 
 .calendar-day {
   position: relative;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid #d1d5db;
 }
 
 .calendar-day:last-child {
@@ -38,15 +39,27 @@
   padding: 2px 0;
 }
 
-.employee-labels {
-  display: grid;
-  grid-auto-flow: column;
+
+.employee-col {
+  position: relative;
+  padding-top: 20px;
 }
 
-.employee-labels .label {
+.employee-col:not(:first-child) {
+  border-left: 1px solid #f3f4f6;
+}
+
+.employee-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
   text-align: center;
   font-size: 12px;
   font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .day-grid {
@@ -57,32 +70,46 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
-}
-
-.item.circle { border-radius: 50%; }
-.item.pill {
-  border-radius: 6px;
+  transition: all .2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--bg-color);
+  height: var(--item-height);
+}
+
+.item.circle {
+  border-radius: 50%;
+  width: 12px;
+  height: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.item.pill {
+  border-radius: 999px;
+  left: 10%;
+  width: 80%;
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
 
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
+.item-content {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+}
+
+.item:hover {
+  background: transparent;
+  left: 0;
+  width: 180px;
+  height: auto;
+  border-radius: 4px;
+  transform: none;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item:hover .item-content {
+  display: block;
+}

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -6,6 +6,7 @@ import type {
   AnyRecord,
   LeadRecord,
   PatientCheckinRecord,
+  CalendarItem,
 } from "../types.ts";
 import {
   toDate,
@@ -13,12 +14,12 @@ import {
   normalizeWeekStart,
   minutesFromDayStart,
   dayIndexFromWeekStart,
-  formatRange,
 } from "../utils/date";
 import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
 import EventBox from "./EventBox";
 import PatientCheckinBox from "./PatientCheckinBox";
+import EmployeeColumn from "./EmployeeColumn";
 import "./WeeklyCalendar.css";
 
 const HOUR_HEIGHT = 40; // px per hour
@@ -29,16 +30,6 @@ const palette: Record<RecordKind, string> = {
   "Patient Checkin": "#ea580c",
 };
 
-type Positioned = {
-  day: number;
-  col: number;
-  top: number;
-  height: number;
-  kind: "circle" | "pill";
-  color: string;
-  rec: AnyRecord;
-  type: RecordKind;
-};
 
 interface Props {
   data: EmployeeData[];
@@ -51,8 +42,8 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     ? normalizeWeekStart(weekStart)
     : normalizeWeekStart(new Date());
 
-  const items = useMemo<Positioned[]>(() => {
-    const out: Positioned[] = [];
+  const items = useMemo<CalendarItem[]>(() => {
+    const out: CalendarItem[] = [];
 
     data.forEach((emp, colIdx) => {
       emp.records.forEach((grp) => {
@@ -65,18 +56,22 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
             const en = toDate(ev.end);
             const day = dayIndexFromWeekStart(st, base);
 
-            out.push({
-              day,
-              col: colIdx + 1,
-              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
-              height: Math.max(
-                (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
-                HOUR_HEIGHT / 2
-              ),
-              kind: "pill",
-              color: palette.Event,
-              rec: r,
-              type: "Event",
+            ev.employees.forEach((ename) => {
+              const idx = data.findIndex((e) => e.employee === ename);
+              if (idx === -1) return;
+              out.push({
+                day,
+                col: idx + 1,
+                top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
+                height: Math.max(
+                  (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
+                  HOUR_HEIGHT / 2
+                ),
+                kind: "pill",
+                color: palette.Event,
+                rec: r,
+                type: "Event",
+              });
             });
           } else {
             const ts =
@@ -148,13 +143,6 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
       {days.map((day, di) => (
         <div key={di} className="calendar-day">
           <div className="day-header">{format(day, "EEE MM/dd")}</div>
-          <div className="employee-labels" style={{ gridTemplateColumns: `repeat(${data.length}, 1fr)` }}>
-            {data.map((emp) => (
-              <div key={emp.employee} className="label">
-                {abbr(emp.employee)}
-              </div>
-            ))}
-          </div>
           <div
             className="day-grid"
             style={{
@@ -162,22 +150,16 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
               height: dayHeight,
             }}
           >
-            {items.filter((it) => it.day === di).map((it, i) => (
-              <div
-                key={i}
-                className={`item ${it.kind}`}
-                style={{
-                  gridColumnStart: it.col,
-                  top: `${it.top}px`,
-                  height: it.kind === "circle" ? 12 : it.height,
-                  background: it.color,
-                }}
-              >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
+            {data.map((emp, idx) => (
+              <EmployeeColumn
+                key={emp.employee}
+                label={abbr(emp.employee)}
+                items={items.filter(
+                  (it) => it.day === di && it.col === idx + 1,
                 )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
-              </div>
+                dayHeight={dayHeight}
+                renderBox={renderBox}
+              />
             ))}
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ a:hover {
   color: #535bf2;
 }
 
+html, body, #root {
+  width: 100%;
+}
+
 body {
   margin: 0;
   display: flex;
@@ -52,6 +56,12 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+.calendar-controls {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,14 @@ export interface EmployeeData {
 employee: string;
 records: RecordGroup[];
 }
+
+export interface CalendarItem {
+  day: number;
+  col: number;
+  top: number;
+  height: number;
+  kind: "circle" | "pill";
+  color: string;
+  rec: AnyRecord;
+  type: RecordKind;
+}


### PR DESCRIPTION
## Summary
- allow navigating weeks and creating records
- mark employee column and day boundaries with subtle lines
- make the calendar grid width fill its container
- provide top bar with controls for adding records

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac