### PR TITLE
Add modal forms for record creation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,103 @@
-import React from "react";
+import React, { useState } from "react";
 import WeeklyCalendar from "./components/WeeklyCalendar";
-import type { EmployeeData } from "./types";
+import CalendarControls from "./components/CalendarControls";
+import Modal from "./components/Modal";
+import LeadForm from "./components/LeadForm";
+import EventForm from "./components/EventForm";
+import CheckinForm from "./components/CheckinForm";
+import type {
+  EmployeeData,
+  LeadRecord,
+  EventRecord,
+  PatientCheckinRecord,
+} from "./types";
 import { normalizeWeekStart } from "./utils/date";
 import data from "./data/fake_data.json";
+import { addDays } from "date-fns";
 import "./components/WeeklyCalendar.css";
 import "./components/RecordBox.css";
 
-const employees = data as unknown as EmployeeData[];
+const initial = data as unknown as EmployeeData[];
 
-const App: React.FC = () => (
-  <WeeklyCalendar
-    data={employees}
-    weekStart={normalizeWeekStart(new Date())}
-  />
-);
+const App: React.FC = () => {
+  const [weekStart, setWeekStart] = useState(normalizeWeekStart(new Date()));
+  const [employees, setEmployees] = useState<EmployeeData[]>(initial);
+  const [modal, setModal] = useState<"lead" | "event" | "checkin" | null>(null);
+
+  const addRecord = (
+    empName: string,
+    type: "Lead" | "Event" | "Patient Checkin",
+    rec: LeadRecord | EventRecord | PatientCheckinRecord,
+  ) => {
+    setEmployees((prev) =>
+      prev.map((emp) => {
+        if (emp.employee !== empName) return emp;
+        const groups = [...emp.records];
+        const idx = groups.findIndex((g) => g.type === type);
+        if (idx >= 0) {
+          groups[idx] = {
+            ...groups[idx],
+            records: [...groups[idx].records, rec],
+          };
+        } else {
+          groups.push({ type, records: [rec] });
+        }
+        return { ...emp, records: groups };
+      }),
+    );
+  };
+
+  const addLead = () => setModal("lead");
+
+  const addEvent = () => setModal("event");
+
+  const addCheckin = () => setModal("checkin");
+
+  const nextWeek = () => setWeekStart((w) => addDays(w, 7));
+  const prevWeek = () => setWeekStart((w) => addDays(w, -7));
+
+  return (
+    <div>
+      <CalendarControls
+        onPrev={prevWeek}
+        onNext={nextWeek}
+        onAddLead={addLead}
+        onAddEvent={addEvent}
+        onAddCheckin={addCheckin}
+      />
+      <WeeklyCalendar data={employees} weekStart={weekStart} />
+      <Modal open={modal === "lead"} onClose={() => setModal(null)}>
+        <LeadForm
+          employees={employees}
+          onCancel={() => setModal(null)}
+          onSubmit={(emp, rec) => {
+            addRecord(emp, "Lead", rec);
+            setModal(null);
+          }}
+        />
+      </Modal>
+      <Modal open={modal === "event"} onClose={() => setModal(null)}>
+        <EventForm
+          employees={employees}
+          onCancel={() => setModal(null)}
+          onSubmit={(emps, rec) => {
+            emps.forEach((e) => addRecord(e, "Event", rec));
+            setModal(null);
+          }}
+        />
+      </Modal>
+      <Modal open={modal === "checkin"} onClose={() => setModal(null)}>
+        <CheckinForm
+          employees={employees}
+          onCancel={() => setModal(null)}
+          onSubmit={(emp, rec) => {
+            addRecord(emp, "Patient Checkin", rec);
+            setModal(null);
+          }}
+        />
+      </Modal>
+    </div>
+  );
+};
 
 export default App;

--- a/src/components/CalendarControls.tsx
+++ b/src/components/CalendarControls.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  onPrev: () => void;
+  onNext: () => void;
+  onAddLead: () => void;
+  onAddEvent: () => void;
+  onAddCheckin: () => void;
+}
+
+const CalendarControls: React.FC<Props> = ({
+  onPrev,
+  onNext,
+  onAddLead,
+  onAddEvent,
+  onAddCheckin,
+}) => (
+  <div className="calendar-controls">
+    <button onClick={onPrev}>Prev Week</button>
+    <button onClick={onNext}>Next Week</button>
+    <button onClick={onAddLead}>Add Lead</button>
+    <button onClick={onAddEvent}>Add Event</button>
+    <button onClick={onAddCheckin}>Add Checkin</button>
+  </div>
+);
+
+export default CalendarControls;

--- a/src/components/CheckinForm.tsx
+++ b/src/components/CheckinForm.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from "react";
+import type { EmployeeData, PatientCheckinRecord } from "../types";
+import { format, parseISO } from "date-fns";
+
+interface Props {
+  employees: EmployeeData[];
+  onSubmit: (emp: string, rec: PatientCheckinRecord) => void;
+  onCancel: () => void;
+}
+
+const CheckinForm: React.FC<Props> = ({ employees, onSubmit, onCancel }) => {
+  const [employee, setEmployee] = useState(employees[0]?.employee ?? "");
+  const [patient, setPatient] = useState("");
+  const [notes, setNotes] = useState("");
+  const [checkin, setCheckin] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const record: PatientCheckinRecord = {
+      patient,
+      notes,
+      checkin: format(parseISO(checkin), "MM/dd/yyyy h:mma"),
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    };
+    onSubmit(employee, record);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Add Check-in</h3>
+      <select value={employee} onChange={(e) => setEmployee(e.target.value)}>
+        {employees.map((emp) => (
+          <option key={emp.employee} value={emp.employee}>
+            {emp.employee}
+          </option>
+        ))}
+      </select>
+      <input
+        required
+        placeholder="Patient"
+        value={patient}
+        onChange={(e) => setPatient(e.target.value)}
+      />
+      <input
+        required
+        type="datetime-local"
+        value={checkin}
+        onChange={(e) => setCheckin(e.target.value)}
+      />
+      <textarea
+        placeholder="Notes"
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+      />
+      <div className="modal-actions">
+        <button type="button" onClick={onCancel}>Cancel</button>
+        <button type="submit">Add</button>
+      </div>
+    </form>
+  );
+};
+
+export default CheckinForm;

--- a/src/components/EmployeeColumn.tsx
+++ b/src/components/EmployeeColumn.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { CalendarItem, RecordKind, AnyRecord } from "../types";
+
+interface Props {
+  label: string;
+  items: CalendarItem[];
+  dayHeight: number;
+  renderBox: (rec: AnyRecord, type: RecordKind) => React.ReactNode;
+}
+
+const EmployeeColumn: React.FC<Props> = ({ label, items, dayHeight, renderBox }) => (
+  <div className="employee-col" style={{ height: dayHeight }}>
+    <div className="employee-label">{label}</div>
+    {items.map((it, i) => (
+      <div
+        key={i}
+        className={`item ${it.kind}`}
+        style={{
+          top: `${it.top}px`,
+          "--item-height": it.kind === "circle" ? "12px" : `${it.height}px`,
+          "--bg-color": it.color,
+        } as React.CSSProperties}
+      >
+        <div className="item-content">{renderBox(it.rec, it.type)}</div>
+      </div>
+    ))}
+  </div>
+);
+
+export default EmployeeColumn;

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import type { EmployeeData, EventRecord } from "../types";
+import { format, parseISO } from "date-fns";
+
+interface Props {
+  employees: EmployeeData[];
+  onSubmit: (emp: string[], rec: EventRecord) => void;
+  onCancel: () => void;
+}
+
+const EventForm: React.FC<Props> = ({ employees, onSubmit, onCancel }) => {
+  const [title, setTitle] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const toggleEmployee = (name: string) => {
+    setSelected((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const record: EventRecord = {
+      title,
+      start: format(parseISO(start), "MM/dd/yyyy h:mma"),
+      end: format(parseISO(end), "MM/dd/yyyy h:mma"),
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+      employees: selected,
+    };
+    onSubmit(selected, record);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Add Event</h3>
+      <input
+        required
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <label>
+        Start
+        <input
+          type="datetime-local"
+          value={start}
+          onChange={(e) => setStart(e.target.value)}
+          required
+        />
+      </label>
+      <label>
+        End
+        <input
+          type="datetime-local"
+          value={end}
+          onChange={(e) => setEnd(e.target.value)}
+          required
+        />
+      </label>
+      <div>
+        Employees
+        {employees.map((emp) => (
+          <label key={emp.employee} style={{ display: "block" }}>
+            <input
+              type="checkbox"
+              checked={selected.includes(emp.employee)}
+              onChange={() => toggleEmployee(emp.employee)}
+            />
+            {emp.employee}
+          </label>
+        ))}
+      </div>
+      <div className="modal-actions">
+        <button type="button" onClick={onCancel}>Cancel</button>
+        <button type="submit">Add</button>
+      </div>
+    </form>
+  );
+};
+
+export default EventForm;

--- a/src/components/LeadForm.tsx
+++ b/src/components/LeadForm.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import type { EmployeeData, LeadRecord } from "../types";
+import { format } from "date-fns";
+
+interface Props {
+  employees: EmployeeData[];
+  onSubmit: (emp: string, rec: LeadRecord) => void;
+  onCancel: () => void;
+}
+
+const LeadForm: React.FC<Props> = ({ employees, onSubmit, onCancel }) => {
+  const [employee, setEmployee] = useState(employees[0]?.employee ?? "");
+  const [firstname, setFirstname] = useState("");
+  const [lastname, setLastname] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const record: LeadRecord = {
+      firstname,
+      lastname,
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    };
+    onSubmit(employee, record);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h3>Add Lead</h3>
+      <select value={employee} onChange={(e) => setEmployee(e.target.value)}>
+        {employees.map((emp) => (
+          <option key={emp.employee} value={emp.employee}>
+            {emp.employee}
+          </option>
+        ))}
+      </select>
+      <input
+        required
+        placeholder="First Name"
+        value={firstname}
+        onChange={(e) => setFirstname(e.target.value)}
+      />
+      <input
+        required
+        placeholder="Last Name"
+        value={lastname}
+        onChange={(e) => setLastname(e.target.value)}
+      />
+      <div className="modal-actions">
+        <button type="button" onClick={onCancel}>Cancel</button>
+        <button type="submit">Add</button>
+      </div>
+    </form>
+  );
+};
+
+export default LeadForm;

--- a/src/components/Modal.css
+++ b/src/components/Modal.css
@@ -1,0 +1,30 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+}
+
+.modal {
+  background: #ffffff;
+  padding: 16px;
+  border-radius: 4px;
+  max-width: 320px;
+  width: 100%;
+}
+
+.modal form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "./Modal.css";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<Props> = ({ open, onClose, children }) => {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/RecordBox.css
+++ b/src/components/RecordBox.css
@@ -5,6 +5,7 @@
   padding: 8px;
   font-size: 12px;
   background: #ffffff;
+  color: #000000;
   border-radius: 4px;
   box-shadow: 0 0 2px rgba(0, 0, 0, .35);
   max-width: 180px;

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -23,7 +24,7 @@
 
 .calendar-day {
   position: relative;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid #d1d5db;
 }
 
 .calendar-day:last-child {
@@ -38,15 +39,32 @@
   padding: 2px 0;
 }
 
-.employee-labels {
-  display: grid;
-  grid-auto-flow: column;
+
+.employee-col {
+  position: relative;
+  padding-top: 20px;
+  transition: background .2s ease;
 }
 
-.employee-labels .label {
+.employee-col:not(:first-child) {
+  border-left: 1px solid #f3f4f6;
+}
+
+.employee-col:hover {
+  background: #e5e7eb;
+}
+
+.employee-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
   text-align: center;
   font-size: 12px;
   font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .day-grid {
@@ -57,32 +75,46 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
-}
-
-.item.circle { border-radius: 50%; }
-.item.pill {
-  border-radius: 6px;
+  transition: all .2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--bg-color);
+  height: var(--item-height);
+}
+
+.item.circle {
+  border-radius: 50%;
+  width: calc(100% - 2px);
+  left: 1px;
+  aspect-ratio: 1 / 1;
+  height: auto;
+}
+
+.item.pill {
+  border-radius: 999px;
+  left: 1px;
+  width: calc(100% - 2px);
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
 
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
+.item-content {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+}
+
+.item:hover {
+  background: transparent;
+  left: 0;
+  width: 180px;
+  height: auto;
+  border-radius: 4px;
+  transform: none;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item:hover .item-content {
+  display: block;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ a:hover {
   color: #535bf2;
 }
 
+html, body, #root {
+  width: 100%;
+}
+
 body {
   margin: 0;
   display: flex;
@@ -52,6 +56,12 @@ button:hover {
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
+}
+
+.calendar-controls {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,14 @@ export interface EmployeeData {
 employee: string;
 records: RecordGroup[];
 }
+
+export interface CalendarItem {
+  day: number;
+  col: number;
+  top: number;
+  height: number;
+  kind: "circle" | "pill";
+  color: string;
+  rec: AnyRecord;
+  type: RecordKind;
+}


### PR DESCRIPTION
## Summary
- add reusable Modal component with overlay styling
- implement LeadForm, EventForm, and CheckinForm for creating records
- open modal forms from CalendarControls in App
- make pills and circles span employee columns with margin and grey column hover

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac