### PR TITLE
Add record entry modals and refine calendar styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,98 @@
-import React from "react";
+import React, { useState } from "react";
 import WeeklyCalendar from "./components/WeeklyCalendar";
-import type { EmployeeData } from "./types";
+import CalendarControls from "./components/CalendarControls";
+import LeadModal from "./components/LeadModal";
+import EventModal from "./components/EventModal";
+import CheckinModal from "./components/CheckinModal";
+import type {
+  EmployeeData,
+  LeadRecord,
+  EventRecord,
+  PatientCheckinRecord,
+} from "./types";
 import { normalizeWeekStart } from "./utils/date";
 import data from "./data/fake_data.json";
+import { addDays } from "date-fns";
 import "./components/WeeklyCalendar.css";
 import "./components/RecordBox.css";
 
-const employees = data as unknown as EmployeeData[];
+const initial = data as unknown as EmployeeData[];
 
-const App: React.FC = () => (
-  <WeeklyCalendar
-    data={employees}
-    weekStart={normalizeWeekStart(new Date())}
-  />
-);
+const App: React.FC = () => {
+  const [weekStart, setWeekStart] = useState(normalizeWeekStart(new Date()));
+  const [employees, setEmployees] = useState<EmployeeData[]>(initial);
+  const [leadOpen, setLeadOpen] = useState(false);
+  const [eventOpen, setEventOpen] = useState(false);
+  const [checkinOpen, setCheckinOpen] = useState(false);
+
+  const addRecord = (
+    empName: string,
+    type: "Lead" | "Event" | "Patient Checkin",
+    rec: LeadRecord | EventRecord | PatientCheckinRecord,
+  ) => {
+    setEmployees((prev) =>
+      prev.map((emp) => {
+        if (emp.employee !== empName) return emp;
+        const groups = [...emp.records];
+        const idx = groups.findIndex((g) => g.type === type);
+        if (idx >= 0) {
+          groups[idx] = {
+            ...groups[idx],
+            records: [...groups[idx].records, rec],
+          };
+        } else {
+          groups.push({ type, records: [rec] });
+        }
+        return { ...emp, records: groups };
+      }),
+    );
+  };
+
+  const saveLead = (emp: string, rec: LeadRecord) => {
+    addRecord(emp, "Lead", rec);
+  };
+
+  const saveEvent = (rec: EventRecord) => {
+    rec.employees.forEach((e) => addRecord(e, "Event", rec));
+  };
+
+  const saveCheckin = (emp: string, rec: PatientCheckinRecord) => {
+    addRecord(emp, "Patient Checkin", rec);
+  };
+
+  const nextWeek = () => setWeekStart((w) => addDays(w, 7));
+  const prevWeek = () => setWeekStart((w) => addDays(w, -7));
+
+  return (
+    <div>
+      <CalendarControls
+        onPrev={prevWeek}
+        onNext={nextWeek}
+        onAddLead={() => setLeadOpen(true)}
+        onAddEvent={() => setEventOpen(true)}
+        onAddCheckin={() => setCheckinOpen(true)}
+      />
+      <WeeklyCalendar data={employees} weekStart={weekStart} />
+      <LeadModal
+        open={leadOpen}
+        employees={employees.map((e) => e.employee)}
+        onClose={() => setLeadOpen(false)}
+        onSave={saveLead}
+      />
+      <EventModal
+        open={eventOpen}
+        employees={employees.map((e) => e.employee)}
+        onClose={() => setEventOpen(false)}
+        onSave={saveEvent}
+      />
+      <CheckinModal
+        open={checkinOpen}
+        employees={employees.map((e) => e.employee)}
+        onClose={() => setCheckinOpen(false)}
+        onSave={saveCheckin}
+      />
+    </div>
+  );
+};
 
 export default App;

--- a/src/components/CalendarControls.tsx
+++ b/src/components/CalendarControls.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+interface Props {
+  onPrev: () => void;
+  onNext: () => void;
+  onAddLead: () => void;
+  onAddEvent: () => void;
+  onAddCheckin: () => void;
+}
+
+const CalendarControls: React.FC<Props> = ({
+  onPrev,
+  onNext,
+  onAddLead,
+  onAddEvent,
+  onAddCheckin,
+}) => (
+  <div className="calendar-controls">
+    <button onClick={onPrev}>Prev Week</button>
+    <button onClick={onNext}>Next Week</button>
+    <button onClick={onAddLead}>Add Lead</button>
+    <button onClick={onAddEvent}>Add Event</button>
+    <button onClick={onAddCheckin}>Add Checkin</button>
+  </div>
+);
+
+export default CalendarControls;

--- a/src/components/CheckinModal.tsx
+++ b/src/components/CheckinModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react";
+import { format } from "date-fns";
+import type { PatientCheckinRecord } from "../types";
+import Modal from "./Modal";
+
+interface Props {
+  open: boolean;
+  employees: string[];
+  onClose: () => void;
+  onSave: (emp: string, rec: PatientCheckinRecord) => void;
+}
+
+const CheckinModal: React.FC<Props> = ({ open, employees, onClose, onSave }) => {
+  const [emp, setEmp] = useState(employees[0] ?? "");
+  const [patient, setPatient] = useState("");
+  const [notes, setNotes] = useState("");
+  const [checkin, setCheckin] = useState("");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!checkin) return;
+    onSave(emp, {
+      patient,
+      notes,
+      checkin: format(new Date(checkin), "MM/dd/yyyy h:mma"),
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    });
+    onClose();
+    setPatient("");
+    setNotes("");
+    setCheckin("");
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={submit} className="form">
+        <h3>Patient Check-in</h3>
+        <label>
+          Employee
+          <select value={emp} onChange={(e) => setEmp(e.target.value)}>
+            {employees.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          Patient
+          <input value={patient} onChange={(e) => setPatient(e.target.value)} />
+        </label>
+        <label>
+          Notes
+          <input value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </label>
+        <label>
+          Check-in
+          <input
+            type="datetime-local"
+            value={checkin}
+            onChange={(e) => setCheckin(e.target.value)}
+          />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </Modal>
+  );
+};
+
+export default CheckinModal;

--- a/src/components/EmployeeColumn.tsx
+++ b/src/components/EmployeeColumn.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { CalendarItem, RecordKind, AnyRecord } from "../types";
+
+interface Props {
+  label: string;
+  items: CalendarItem[];
+  dayHeight: number;
+  renderBox: (rec: AnyRecord, type: RecordKind) => React.ReactNode;
+}
+
+const EmployeeColumn: React.FC<Props> = ({ label, items, dayHeight, renderBox }) => (
+  <div className="employee-col" style={{ height: dayHeight }}>
+    <div className="employee-label">{label}</div>
+    {items.map((it, i) => (
+      <div
+        key={i}
+        className={`item ${it.kind}`}
+        style={{
+          top: `${it.top}px`,
+          "--item-height": it.kind === "circle" ? "12px" : `${it.height}px`,
+          "--bg-color": it.color,
+        } as React.CSSProperties}
+      >
+        <div className="item-content">{renderBox(it.rec, it.type)}</div>
+      </div>
+    ))}
+  </div>
+);
+
+export default EmployeeColumn;

--- a/src/components/EventModal.tsx
+++ b/src/components/EventModal.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from "react";
+import { format } from "date-fns";
+import type { EventRecord } from "../types";
+import Modal from "./Modal";
+
+interface Props {
+  open: boolean;
+  employees: string[];
+  onClose: () => void;
+  onSave: (rec: EventRecord) => void;
+}
+
+const EventModal: React.FC<Props> = ({ open, employees, onClose, onSave }) => {
+  const [title, setTitle] = useState("");
+  const [start, setStart] = useState("");
+  const [end, setEnd] = useState("");
+  const [assigned, setAssigned] = useState<string[]>([]);
+
+  const toggle = (name: string) => {
+    setAssigned((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name],
+    );
+  };
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!start || !end || assigned.length === 0) return;
+    onSave({
+      title,
+      start: format(new Date(start), "MM/dd/yyyy h:mma"),
+      end: format(new Date(end), "MM/dd/yyyy h:mma"),
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+      employees: assigned,
+    });
+    onClose();
+    setTitle("");
+    setStart("");
+    setEnd("");
+    setAssigned([]);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={submit} className="form">
+        <h3>New Event</h3>
+        <label>
+          Title
+          <input value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <label>
+          Start
+          <input
+            type="datetime-local"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+          />
+        </label>
+        <label>
+          End
+          <input
+            type="datetime-local"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+          />
+        </label>
+        <fieldset>
+          <legend>Employees</legend>
+          {employees.map((name) => (
+            <label key={name} style={{ display: "block" }}>
+              <input
+                type="checkbox"
+                checked={assigned.includes(name)}
+                onChange={() => toggle(name)}
+              />
+              {name}
+            </label>
+          ))}
+        </fieldset>
+        <button type="submit">Save</button>
+      </form>
+    </Modal>
+  );
+};
+
+export default EventModal;

--- a/src/components/LeadModal.tsx
+++ b/src/components/LeadModal.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import { format } from "date-fns";
+import type { LeadRecord } from "../types";
+import Modal from "./Modal";
+
+interface Props {
+  open: boolean;
+  employees: string[];
+  onClose: () => void;
+  onSave: (emp: string, rec: LeadRecord) => void;
+}
+
+const LeadModal: React.FC<Props> = ({ open, employees, onClose, onSave }) => {
+  const [emp, setEmp] = useState(employees[0] ?? "");
+  const [firstname, setFirstname] = useState("");
+  const [lastname, setLastname] = useState("");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(emp, {
+      firstname,
+      lastname,
+      create: format(new Date(), "MM/dd/yyyy h:mma"),
+    });
+    onClose();
+    setFirstname("");
+    setLastname("");
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <form onSubmit={submit} className="form">
+        <h3>New Lead</h3>
+        <label>
+          Employee
+          <select value={emp} onChange={(e) => setEmp(e.target.value)}>
+            {employees.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          First Name
+          <input value={firstname} onChange={(e) => setFirstname(e.target.value)} />
+        </label>
+        <label>
+          Last Name
+          <input value={lastname} onChange={(e) => setLastname(e.target.value)} />
+        </label>
+        <button type="submit">Save</button>
+      </form>
+    </Modal>
+  );
+};
+
+export default LeadModal;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<Props> = ({ open, onClose, children }) => {
+  if (!open) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/RecordBox.css
+++ b/src/components/RecordBox.css
@@ -5,6 +5,7 @@
   padding: 8px;
   font-size: 12px;
   background: #ffffff;
+  color: #000000;
   border-radius: 4px;
   box-shadow: 0 0 2px rgba(0, 0, 0, .35);
   max-width: 180px;

--- a/src/components/WeeklyCalendar.css
+++ b/src/components/WeeklyCalendar.css
@@ -5,6 +5,7 @@
   overflow: auto;
   display: grid;
   grid-template-columns: 50px repeat(7, 1fr);
+  width: 100%;
 }
 
 .time-col {
@@ -23,7 +24,7 @@
 
 .calendar-day {
   position: relative;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid #d1d5db;
 }
 
 .calendar-day:last-child {
@@ -38,15 +39,31 @@
   padding: 2px 0;
 }
 
-.employee-labels {
-  display: grid;
-  grid-auto-flow: column;
+
+.employee-col {
+  position: relative;
+  padding-top: 20px;
 }
 
-.employee-labels .label {
+.employee-col:not(:first-child) {
+  border-left: 1px solid #f3f4f6;
+}
+
+.employee-col:hover {
+  background: #f3f4f4;
+}
+
+.employee-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
   text-align: center;
   font-size: 12px;
   font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
 }
 
 .day-grid {
@@ -57,32 +74,45 @@
 
 .item {
   position: absolute;
-  left: 10%;
-  width: 80%;
   cursor: pointer;
-  transition: transform .18s ease;
-}
-
-.item.circle { border-radius: 50%; }
-.item.pill {
-  border-radius: 6px;
+  transition: all .2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: var(--bg-color);
+  height: var(--item-height);
+}
+
+.item.circle {
+  border-radius: 50%;
+  left: 1px;
+  width: calc(100% - 2px);
+  height: var(--item-height);
+}
+
+.item.pill {
+  border-radius: 999px;
+  left: 1px;
+  width: calc(100% - 2px);
   color: #ffffff;
   font-size: 10px;
   padding: 0 2px;
 }
 
-.item:hover { transform: scale(1.15); }
-
-.item .hover {
+.item-content {
   display: none;
-  position: absolute;
-  top: 0;
-  left: 100%;
-  margin-left: 6px;
+}
+
+.item:hover {
+  background: transparent;
+  left: 0;
+  width: 180px;
+  height: auto;
+  border-radius: 4px;
+  transform: none;
   z-index: 20;
 }
 
-.item:hover .hover { display: block; }
+.item:hover .item-content {
+  display: block;
+}

--- a/src/components/WeeklyCalendar.tsx
+++ b/src/components/WeeklyCalendar.tsx
@@ -6,6 +6,7 @@ import type {
   AnyRecord,
   LeadRecord,
   PatientCheckinRecord,
+  CalendarItem,
 } from "../types.ts";
 import {
   toDate,
@@ -13,12 +14,12 @@ import {
   normalizeWeekStart,
   minutesFromDayStart,
   dayIndexFromWeekStart,
-  formatRange,
 } from "../utils/date";
 import { format, addDays } from "date-fns";
 import LeadBox from "./LeadBox";
 import EventBox from "./EventBox";
 import PatientCheckinBox from "./PatientCheckinBox";
+import EmployeeColumn from "./EmployeeColumn";
 import "./WeeklyCalendar.css";
 
 const HOUR_HEIGHT = 40; // px per hour
@@ -29,16 +30,6 @@ const palette: Record<RecordKind, string> = {
   "Patient Checkin": "#ea580c",
 };
 
-type Positioned = {
-  day: number;
-  col: number;
-  top: number;
-  height: number;
-  kind: "circle" | "pill";
-  color: string;
-  rec: AnyRecord;
-  type: RecordKind;
-};
 
 interface Props {
   data: EmployeeData[];
@@ -51,8 +42,8 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
     ? normalizeWeekStart(weekStart)
     : normalizeWeekStart(new Date());
 
-  const items = useMemo<Positioned[]>(() => {
-    const out: Positioned[] = [];
+  const items = useMemo<CalendarItem[]>(() => {
+    const out: CalendarItem[] = [];
 
     data.forEach((emp, colIdx) => {
       emp.records.forEach((grp) => {
@@ -65,18 +56,22 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
             const en = toDate(ev.end);
             const day = dayIndexFromWeekStart(st, base);
 
-            out.push({
-              day,
-              col: colIdx + 1,
-              top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
-              height: Math.max(
-                (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
-                HOUR_HEIGHT / 2
-              ),
-              kind: "pill",
-              color: palette.Event,
-              rec: r,
-              type: "Event",
+            ev.employees.forEach((ename) => {
+              const idx = data.findIndex((e) => e.employee === ename);
+              if (idx === -1) return;
+              out.push({
+                day,
+                col: idx + 1,
+                top: minutesFromDayStart(st) * (HOUR_HEIGHT / 60),
+                height: Math.max(
+                  (en.getTime() - st.getTime()) / 60000 * (HOUR_HEIGHT / 60),
+                  HOUR_HEIGHT / 2
+                ),
+                kind: "pill",
+                color: palette.Event,
+                rec: r,
+                type: "Event",
+              });
             });
           } else {
             const ts =
@@ -148,13 +143,6 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
       {days.map((day, di) => (
         <div key={di} className="calendar-day">
           <div className="day-header">{format(day, "EEE MM/dd")}</div>
-          <div className="employee-labels" style={{ gridTemplateColumns: `repeat(${data.length}, 1fr)` }}>
-            {data.map((emp) => (
-              <div key={emp.employee} className="label">
-                {abbr(emp.employee)}
-              </div>
-            ))}
-          </div>
           <div
             className="day-grid"
             style={{
@@ -162,22 +150,16 @@ const WeeklyCalendar: React.FC<Props> = ({ data, weekStart }) => {
               height: dayHeight,
             }}
           >
-            {items.filter((it) => it.day === di).map((it, i) => (
-              <div
-                key={i}
-                className={`item ${it.kind}`}
-                style={{
-                  gridColumnStart: it.col,
-                  top: `${it.top}px`,
-                  height: it.kind === "circle" ? 12 : it.height,
-                  background: it.color,
-                }}
-              >
-                {it.kind === "pill" && (
-                  <span>{formatRange((it.rec as EventRecord).start, (it.rec as EventRecord).end)}</span>
+            {data.map((emp, idx) => (
+              <EmployeeColumn
+                key={emp.employee}
+                label={abbr(emp.employee)}
+                items={items.filter(
+                  (it) => it.day === di && it.col === idx + 1,
                 )}
-                <div className="hover">{renderBox(it.rec, it.type)}</div>
-              </div>
+                dayHeight={dayHeight}
+                renderBox={renderBox}
+              />
             ))}
           </div>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,10 @@ a:hover {
   color: #535bf2;
 }
 
+html, body, #root {
+  width: 100%;
+}
+
 body {
   margin: 0;
   display: flex;
@@ -54,6 +58,12 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.calendar-controls {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -65,4 +75,40 @@ button:focus-visible {
   button {
     background-color: #f9f9f9;
   }
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: #ffffff;
+  padding: 16px;
+  border-radius: 8px;
+  min-width: 280px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+}
+
+.form h3 {
+  margin: 0 0 8px;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,3 +33,14 @@ export interface EmployeeData {
 employee: string;
 records: RecordGroup[];
 }
+
+export interface CalendarItem {
+  day: number;
+  col: number;
+  top: number;
+  height: number;
+  kind: "circle" | "pill";
+  color: string;
+  rec: AnyRecord;
+  type: RecordKind;
+}


### PR DESCRIPTION
## Summary
- introduce generic Modal component and record form modals
- hook CalendarControls to open modals for creating leads, events and check-ins
- store new records from modal forms
- stretch items to column width with margin and highlight columns on hover
- style modal overlay and forms

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68893b01596483208c50db66805702ac