### PR TITLE
Implement DB-driven forms

### DIFF
--- a/server/seed_form_data.js
+++ b/server/seed_form_data.js
@@ -1,0 +1,20 @@
+import { openDb } from './db.js';
+
+const db = await openDb();
+
+await db.exec(`DELETE FROM formfields; DELETE FROM formsubtabs; DELETE FROM formrecords; DELETE FROM fields; DELETE FROM records;`);
+
+const recRes = await db.run("INSERT INTO records(name, table_name) VALUES ('employee', 'employees')");
+const recId = recRes.lastID;
+const fldRes = await db.run("INSERT INTO fields(record_id, name, type) VALUES (?, 'name', 'text')", [recId]);
+const fldId = fldRes.lastID;
+const quickRes = await db.run("INSERT INTO formrecords(record_id, form_type, label) VALUES (?, 'quickadd', 'Add Employee')", [recId]);
+const hoverRes = await db.run("INSERT INTO formrecords(record_id, form_type, label) VALUES (?, 'hover', 'Employee Info')", [recId]);
+const summaryRes = await db.run("INSERT INTO formrecords(record_id, form_type, label) VALUES (?, 'summary', 'Employee Summary')", [recId]);
+const subRes = await db.run("INSERT INTO formsubtabs(form_id, label, ord) VALUES (?, 'General', 1)", [summaryRes.lastID]);
+const subId = subRes.lastID;
+await db.run("INSERT INTO formfields(form_id, field_id, ord, readonly, label) VALUES (?, ?, 1, 0, 'Name')", [quickRes.lastID, fldId]);
+await db.run("INSERT INTO formfields(form_id, field_id, ord, readonly, label) VALUES (?, ?, 1, 1, 'Name')", [hoverRes.lastID, fldId]);
+await db.run("INSERT INTO formfields(form_id, field_id, subtab_id, ord, readonly, label) VALUES (?, ?, ?, 1, 1, 'Name')", [summaryRes.lastID, fldId, subId]);
+
+await db.close();

--- a/src/components/FormRenderer.tsx
+++ b/src/components/FormRenderer.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+
+export interface FormField {
+  id: number;
+  name: string;
+  type: string;
+  label: string;
+  readonly: number;
+  subtab_id?: number;
+}
+
+export interface FormMeta {
+  id: number;
+  label: string;
+  form_type: string;
+  fields: FormField[];
+  subtabs: { id: number; label: string; ord: number }[];
+}
+
+interface Props {
+  record: string;
+  type: string;
+  mode: 'display' | 'edit';
+  initial?: Record<string, string>;
+  onSubmit?: (values: Record<string, string>) => void;
+}
+
+const FormRenderer: React.FC<Props> = ({ record, type, mode, initial = {}, onSubmit }) => {
+  const [meta, setMeta] = useState<FormMeta | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    fetch(`/api/forms/${record}/${type}`)
+      .then(r => r.json())
+      .then(m => {
+        setMeta(m);
+        const v: Record<string, string> = {};
+        m.fields.forEach((f: FormField) => {
+          v[f.name] = initial[f.name] ?? '';
+        });
+        setValues(v);
+      });
+  }, [record, type, initial]);
+
+  if (!meta) return null;
+
+  const change = (name: string, value: string) => {
+    setValues(prev => ({ ...prev, [name]: value }));
+  };
+
+  const submit = () => {
+    onSubmit?.(values);
+  };
+
+  return (
+    <div className={`form-renderer ${type}`}>
+      {meta.fields.map(f => (
+        <div key={f.id} className="form-field">
+          {mode === 'edit' && !f.readonly ? (
+            <input
+              value={values[f.name]}
+              onChange={e => change(f.name, e.target.value)}
+              placeholder={f.label}
+            />
+          ) : (
+            <div>
+              <strong>{f.label}</strong>: {values[f.name]}
+            </div>
+          )}
+        </div>
+      ))}
+      {mode === 'edit' && onSubmit && (
+        <button onClick={submit}>Submit</button>
+      )}
+    </div>
+  );
+};
+
+export default FormRenderer;

--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import FormRenderer from './FormRenderer';
+
+interface Props {
+  record: string;
+  data: Record<string, string>;
+}
+
+const HoverCard: React.FC<Props> = ({ record, data }) => (
+  <FormRenderer record={record} type="hover" mode="display" initial={data} />
+);
+
+export default HoverCard;

--- a/src/components/QuickAddForm.tsx
+++ b/src/components/QuickAddForm.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import FormRenderer from './FormRenderer';
+
+interface Props {
+  record: string;
+  onSubmit: (values: Record<string, string>) => void;
+}
+
+const QuickAddForm: React.FC<Props> = ({ record, onSubmit }) => (
+  <FormRenderer record={record} type="quickadd" mode="edit" onSubmit={onSubmit} />
+);
+
+export default QuickAddForm;

--- a/src/components/SummaryView.tsx
+++ b/src/components/SummaryView.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import FormRenderer from './FormRenderer';
+
+interface Props {
+  record: string;
+  data: Record<string, string>;
+}
+
+const SummaryView: React.FC<Props> = ({ record, data }) => (
+  <FormRenderer record={record} type="summary" mode="display" initial={data} />
+);
+
+export default SummaryView;


### PR DESCRIPTION
## Summary
- create new form metadata tables in SQLite and seed data for employees
- expose API endpoint `/api/forms/:record/:type`
- seed initial form data via script
- add React form renderer for dynamic QuickAdd, summary, and hover views

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889d314114c8320964bdd613fbaebde