### PR TITLE
Add DB form metadata and dynamic forms

### DIFF
--- a/server/add_form_data.js
+++ b/server/add_form_data.js
@@ -1,0 +1,62 @@
+import { openDb } from './db.js';
+
+async function main() {
+  const db = await openDb();
+
+  const empRec = await db.run("INSERT INTO records(name) VALUES ('Employee')");
+  const empRecId = empRec.lastID;
+  const empField = await db.run(
+    'INSERT INTO fields(record_id, name, type) VALUES (?, ?, ?)',
+    [empRecId, 'name', 'text']
+  );
+  const empForm = await db.run(
+    "INSERT INTO formrecord(record_id, form_type, title) VALUES (?, 'main', 'Employee')",
+    [empRecId]
+  );
+  const empSub = await db.run(
+    'INSERT INTO formsubtabs(form_id, label, ord) VALUES (?, ?, ?)',
+    [empForm.lastID, 'General', 1]
+  );
+  await db.run(
+    'INSERT INTO formfields(form_id, field_id, ord, readonly, subtab_id) VALUES (?, ?, ?, ?, ?)',
+    [empForm.lastID, empField.lastID, 1, 0, empSub.lastID]
+  );
+
+  const leadRec = await db.run("INSERT INTO records(name) VALUES ('Lead')");
+  const leadId = leadRec.lastID;
+  const f1 = await db.run(
+    'INSERT INTO fields(record_id, name, type) VALUES (?, ?, ?)',
+    [leadId, 'firstname', 'text']
+  );
+  const f2 = await db.run(
+    'INSERT INTO fields(record_id, name, type) VALUES (?, ?, ?)',
+    [leadId, 'lastname', 'text']
+  );
+  const f3 = await db.run(
+    'INSERT INTO fields(record_id, name, type, ref_table) VALUES (?, ?, ?, ?)',
+    [leadId, 'employee', 'foreign', 'employees']
+  );
+  const qform = await db.run(
+    "INSERT INTO formrecord(record_id, form_type, title) VALUES (?, 'quickadd', 'Add Lead')",
+    [leadId]
+  );
+  const sub = await db.run(
+    'INSERT INTO formsubtabs(form_id, label, ord) VALUES (?, ?, ?)',
+    [qform.lastID, 'General', 1]
+  );
+  await db.run(
+    'INSERT INTO formfields(form_id, field_id, ord, readonly, subtab_id) VALUES (?, ?, ?, ?, ?)',
+    [qform.lastID, f3.lastID, 1, 0, sub.lastID]
+  );
+  await db.run(
+    'INSERT INTO formfields(form_id, field_id, ord, readonly, subtab_id) VALUES (?, ?, ?, ?, ?)',
+    [qform.lastID, f1.lastID, 2, 0, sub.lastID]
+  );
+  await db.run(
+    'INSERT INTO formfields(form_id, field_id, ord, readonly, subtab_id) VALUES (?, ?, ?, ?, ?)',
+    [qform.lastID, f2.lastID, 3, 0, sub.lastID]
+  );
+  console.log('Form data inserted');
+}
+
+main();

--- a/src/components/AddLeadModal.tsx
+++ b/src/components/AddLeadModal.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
-import Modal from './Modal';
+import React from 'react';
+import QuickAdd from './QuickAdd';
 import type { LeadRecord } from '../types';
-import { format } from 'date-fns';
 
 interface Props {
   employees: string[];
@@ -9,42 +8,17 @@ interface Props {
   onClose: () => void;
 }
 
-const AddLeadModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
-  const [employee, setEmployee] = useState(employees[0] || '');
-  const [firstname, setFirstname] = useState('');
-  const [lastname, setLastname] = useState('');
-
-  const submit = () => {
-    const record: LeadRecord = {
-      firstname,
-      lastname,
-      create: format(new Date(), 'MM/dd/yyyy h:mma'),
+const AddLeadModal: React.FC<Props> = ({ onSubmit, onClose }) => {
+  const handle = (data: Record<string, string>) => {
+    const rec: LeadRecord = {
+      firstname: data.firstname,
+      lastname: data.lastname,
+      create: data.create || '',
     };
-    onSubmit(employee, record);
-    onClose();
+    onSubmit(data.employee, rec);
   };
 
-  return (
-    <Modal onClose={onClose}>
-      <h3>Add Lead</h3>
-      <select value={employee} onChange={(e) => setEmployee(e.target.value)}>
-        {employees.map((e) => (
-          <option key={e}>{e}</option>
-        ))}
-      </select>
-      <input
-        placeholder="First name"
-        value={firstname}
-        onChange={(e) => setFirstname(e.target.value)}
-      />
-      <input
-        placeholder="Last name"
-        value={lastname}
-        onChange={(e) => setLastname(e.target.value)}
-      />
-      <button onClick={submit}>Add</button>
-    </Modal>
-  );
+  return <QuickAdd record="Lead" onSubmit={handle} onClose={onClose} />;
 };
 
 export default AddLeadModal;

--- a/src/components/DynamicForm.tsx
+++ b/src/components/DynamicForm.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+
+interface Field {
+  id: number;
+  name: string;
+  type: string;
+  ord: number;
+  readonly: number;
+  subtab?: string;
+}
+
+interface Props {
+  record: string;
+  formType: 'quickadd' | 'hover' | 'main';
+  data?: Record<string, unknown>;
+  onSubmit?: (values: Record<string, string>) => void;
+}
+
+const DynamicForm: React.FC<Props> = ({ record, formType, data, onSubmit }) => {
+  const [fields, setFields] = useState<Field[]>([]);
+  const [values, setValues] = useState<Record<string, string>>(data ? (data as Record<string, string>) : {});
+
+  useEffect(() => {
+    fetch(`/api/form/${record}/${formType}`)
+      .then((r) => r.json())
+      .then((d) => {
+        setFields(d.fields);
+        if (data) setValues(data as Record<string, string>);
+      });
+  }, [record, formType, data]);
+
+  const handleChange = (name: string, value: string) => {
+    setValues((v) => ({ ...v, [name]: value }));
+  };
+
+  const submit = () => {
+    if (onSubmit) onSubmit(values);
+  };
+
+  if (!fields.length) return null;
+
+  return (
+    <div>
+      {fields.map((f) => (
+        <div key={f.id} style={{ marginBottom: '4px' }}>
+          {onSubmit ? (
+            <input
+              placeholder={f.name}
+              value={values[f.name] || ''}
+              onChange={(e) => handleChange(f.name, e.target.value)}
+            />
+          ) : (
+            <span>{values[f.name]}</span>
+          )}
+        </div>
+      ))}
+      {onSubmit && <button onClick={submit}>Submit</button>}
+    </div>
+  );
+};
+
+export default DynamicForm;

--- a/src/components/Hover.tsx
+++ b/src/components/Hover.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import DynamicForm from './DynamicForm';
+
+interface Props {
+  record: string;
+  data: Record<string, unknown>;
+}
+
+const Hover: React.FC<Props> = ({ record, data }) => (
+  <div className="hover-box">
+    <DynamicForm record={record} formType="hover" data={data} />
+  </div>
+);
+
+export default Hover;

--- a/src/components/LeadBox.tsx
+++ b/src/components/LeadBox.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { LeadRecord } from "../types";
+import Hover from "./Hover";
 import "./RecordBox.css";
 
 interface Props {
@@ -8,9 +9,7 @@ interface Props {
 
 const LeadBox: React.FC<Props> = ({ data }) => (
   <div className="record-box lead">
-    <strong>Lead</strong>
-    <div>{data.firstname} {data.lastname}</div>
-    <div className="meta">{data.create}</div>
+    <Hover record="Lead" data={data as unknown as Record<string, unknown>} />
   </div>
 );
 

--- a/src/components/QuickAdd.tsx
+++ b/src/components/QuickAdd.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Modal from './Modal';
+import DynamicForm from './DynamicForm';
+
+interface Props {
+  record: string;
+  onSubmit: (data: Record<string, string>) => void;
+  onClose: () => void;
+}
+
+const QuickAdd: React.FC<Props> = ({ record, onSubmit, onClose }) => (
+  <Modal onClose={onClose}>
+    <h3>Quick Add {record}</h3>
+    <DynamicForm record={record} formType="quickadd" onSubmit={onSubmit} />
+  </Modal>
+);
+
+export default QuickAdd;

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import DynamicForm from './DynamicForm';
+
+interface Props {
+  record: string;
+  data: Record<string, unknown>;
+}
+
+const Summary: React.FC<Props> = ({ record, data }) => (
+  <div className="summary-box">
+    <DynamicForm record={record} formType="main" data={data} />
+  </div>
+);
+
+export default Summary;


### PR DESCRIPTION
## Summary
- add DB tables for form metadata in `initDb`
- populate default employee and lead forms when seeding database
- expose API to retrieve form definitions
- add script to insert form metadata
- implement generic `DynamicForm` renderer and wrapper components
- use dynamic forms in `AddLeadModal` and lead hover box

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889d314114c8320964bdd613fbaebde