### PR TITLE
Add dynamic form data tables and components

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server/index.js"
+    "server": "node server/index.js",
+    "seed:forms": "node server/scripts/add_form_data.js"
   },
   "dependencies": {
     "date-fns": "^4.1.0",

--- a/server/scripts/add_form_data.js
+++ b/server/scripts/add_form_data.js
@@ -1,0 +1,7 @@
+import { openDb, seedForms } from '../db.js';
+
+(async () => {
+  const db = await openDb();
+  await seedForms(db);
+  console.log('Form data inserted');
+})();

--- a/src/components/AddCheckinModal.tsx
+++ b/src/components/AddCheckinModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Modal from './Modal';
 import type { PatientCheckinRecord } from '../types';
 import { format } from 'date-fns';
+import DynamicForm from './DynamicForm';
 
 interface Props {
   employees: string[];
@@ -11,15 +12,13 @@ interface Props {
 
 const AddCheckinModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
   const [employee, setEmployee] = useState(employees[0] || '');
-  const [patient, setPatient] = useState('');
-  const [notes, setNotes] = useState('');
-  const [checkin, setCheckin] = useState('');
+  const [values, setValues] = useState<Record<string, string>>({});
 
   const submit = () => {
     const record: PatientCheckinRecord = {
-      patient,
-      notes,
-      checkin: format(new Date(checkin), 'MM/dd/yyyy h:mma'),
+      patient: values.patient || '',
+      notes: values.notes || '',
+      checkin: format(new Date(values.checkin), 'MM/dd/yyyy h:mma'),
       create: format(new Date(), 'MM/dd/yyyy h:mma'),
     };
     onSubmit(employee, record);
@@ -34,9 +33,7 @@ const AddCheckinModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
           <option key={e}>{e}</option>
         ))}
       </select>
-      <input placeholder="Patient" value={patient} onChange={(e) => setPatient(e.target.value)} />
-      <input placeholder="Notes" value={notes} onChange={(e) => setNotes(e.target.value)} />
-      <input type="datetime-local" value={checkin} onChange={(e) => setCheckin(e.target.value)} />
+      <DynamicForm record="Patient Checkin" formType="quickadd" onChange={setValues} />
       <button onClick={submit}>Add</button>
     </Modal>
   );

--- a/src/components/AddEventModal.tsx
+++ b/src/components/AddEventModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Modal from './Modal';
 import type { EventRecord } from '../types';
 import { format } from 'date-fns';
+import DynamicForm from './DynamicForm';
 
 interface Props {
   employees: string[];
@@ -10,16 +11,14 @@ interface Props {
 }
 
 const AddEventModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
-  const [title, setTitle] = useState('');
-  const [start, setStart] = useState('');
-  const [end, setEnd] = useState('');
   const [selected, setSelected] = useState<string[]>([]);
+  const [values, setValues] = useState<Record<string, string>>({});
 
   const submit = () => {
     const record: EventRecord = {
-      title,
-      start: format(new Date(start), 'MM/dd/yyyy h:mma'),
-      end: format(new Date(end), 'MM/dd/yyyy h:mma'),
+      title: values.title || '',
+      start: format(new Date(values.start), 'MM/dd/yyyy h:mma'),
+      end: format(new Date(values.end), 'MM/dd/yyyy h:mma'),
       create: format(new Date(), 'MM/dd/yyyy h:mma'),
       employees: selected,
     };
@@ -30,9 +29,7 @@ const AddEventModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
   return (
     <Modal onClose={onClose}>
       <h3>Add Event</h3>
-      <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
-      <input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)} />
-      <input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)} />
+      <DynamicForm record="Event" formType="quickadd" onChange={setValues} />
       <select multiple value={selected} onChange={(e) => setSelected(Array.from(e.target.selectedOptions, o => o.value))}>
         {employees.map((e) => (
           <option key={e}>{e}</option>

--- a/src/components/AddLeadModal.tsx
+++ b/src/components/AddLeadModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Modal from './Modal';
 import type { LeadRecord } from '../types';
 import { format } from 'date-fns';
+import DynamicForm from './DynamicForm';
 
 interface Props {
   employees: string[];
@@ -11,13 +12,12 @@ interface Props {
 
 const AddLeadModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
   const [employee, setEmployee] = useState(employees[0] || '');
-  const [firstname, setFirstname] = useState('');
-  const [lastname, setLastname] = useState('');
+  const [values, setValues] = useState<Record<string, string>>({});
 
   const submit = () => {
     const record: LeadRecord = {
-      firstname,
-      lastname,
+      firstname: values.firstname || '',
+      lastname: values.lastname || '',
       create: format(new Date(), 'MM/dd/yyyy h:mma'),
     };
     onSubmit(employee, record);
@@ -32,16 +32,7 @@ const AddLeadModal: React.FC<Props> = ({ employees, onSubmit, onClose }) => {
           <option key={e}>{e}</option>
         ))}
       </select>
-      <input
-        placeholder="First name"
-        value={firstname}
-        onChange={(e) => setFirstname(e.target.value)}
-      />
-      <input
-        placeholder="Last name"
-        value={lastname}
-        onChange={(e) => setLastname(e.target.value)}
-      />
+      <DynamicForm record="Lead" formType="quickadd" onChange={setValues} />
       <button onClick={submit}>Add</button>
     </Modal>
   );

--- a/src/components/DynamicForm.tsx
+++ b/src/components/DynamicForm.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+
+interface Field {
+  id: number;
+  name: string;
+  type: string;
+  label: string;
+  read_only: number;
+}
+
+interface Props {
+  record: string;
+  formType: 'quickadd' | 'main';
+  onSubmit?: (values: Record<string, string>) => void;
+  onChange?: (values: Record<string, string>) => void;
+}
+
+const DynamicForm: React.FC<Props> = ({ record, formType, onSubmit, onChange }) => {
+  const [fields, setFields] = useState<Field[]>([]);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    fetch(`/api/forms/${record}/${formType}`)
+      .then((r) => r.json())
+      .then((d) => {
+        setFields(d.fields);
+        const init: Record<string, string> = {};
+        d.fields.forEach((f: Field) => {
+          init[f.name] = '';
+        });
+        setValues(init);
+      });
+  }, [record, formType]);
+
+  const update = (name: string, val: string) => {
+    setValues((v) => {
+      const out = { ...v, [name]: val };
+      onChange?.(out);
+      return out;
+    });
+  };
+
+  const submit = () => {
+    onSubmit?.(values);
+  };
+
+  return (
+    <div>
+      {fields.map((f) => (
+        <div key={f.id}>
+          <label>{f.label}</label>
+          <input
+            value={values[f.name] || ''}
+            onChange={(e) => update(f.name, e.target.value)}
+            disabled={!!f.read_only}
+          />
+        </div>
+      ))}
+      {onSubmit && <button onClick={submit}>Submit</button>}
+    </div>
+  );
+};
+
+export default DynamicForm;

--- a/src/components/HoverCard.tsx
+++ b/src/components/HoverCard.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+interface Field {
+  id: number;
+  name: string;
+  label: string;
+}
+
+interface Props {
+  record: string;
+  data: Record<string, unknown>;
+}
+
+const HoverCard: React.FC<Props> = ({ record, data }) => {
+  const [fields, setFields] = useState<Field[]>([]);
+  useEffect(() => {
+    fetch(`/api/forms/${record}/hover`)
+      .then((r) => r.json())
+      .then((d) => setFields(d.fields));
+  }, [record]);
+
+  return (
+    <div className="record-box">
+      <strong>{record}</strong>
+      {fields.map((f) => (
+        <div key={f.id}>{String(data[f.name] ?? '')}</div>
+      ))}
+    </div>
+  );
+};
+
+export default HoverCard;

--- a/src/components/SummaryCard.tsx
+++ b/src/components/SummaryCard.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+interface Field {
+  id: number;
+  name: string;
+  label: string;
+}
+
+interface Props {
+  record: string;
+  data: Record<string, unknown>;
+}
+
+const SummaryCard: React.FC<Props> = ({ record, data }) => {
+  const [fields, setFields] = useState<Field[]>([]);
+  useEffect(() => {
+    fetch(`/api/forms/${record}/main`)
+      .then((r) => r.json())
+      .then((d) => setFields(d.fields));
+  }, [record]);
+
+  return (
+    <div className="record-box">
+      <strong>{record}</strong>
+      {fields.map((f) => (
+        <div key={f.id}>{String(data[f.name] ?? '')}</div>
+      ))}
+    </div>
+  );
+};
+
+export default SummaryCard;


### PR DESCRIPTION
## Summary
- add new sqlite tables for record/field/form metadata
- add form seeding script and endpoint to fetch form definitions
- implement a dynamic form component plus hover and summary display
- update modal forms to build their fields dynamically from DB

## Testing
- `npm run lint`
- `npm run build`
- `npm run seed:forms` *(fails: SQLITE_ERROR: no such table: records)*

------
https://chatgpt.com/codex/tasks/task_e_6889d314114c8320964bdd613fbaebde